### PR TITLE
[AI] Create user authentication with login page

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,15 +1,8 @@
 module.exports = {
   testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.js'],
+  collectCoverageFrom: ['src/**/*.js'],
   coverageThreshold: {
-    global: {
-      lines: 80,
-      functions: 80,
-      branches: 80,
-      statements: 80,
-    },
+    global: { lines: 80, functions: 80, branches: 80, statements: 80 },
   },
-  collectCoverageFrom: [
-    'src/**/*.js',
-    '!src/index.js',
-  ],
 };

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  testEnvironment: 'node',
+  coverageThreshold: {
+    global: {
+      lines: 80,
+      functions: 80,
+      branches: 80,
+      statements: 80,
+    },
+  },
+  collectCoverageFrom: [
+    'src/**/*.js',
+    '!src/index.js',
+  ],
+};

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -3,6 +3,11 @@ module.exports = {
   testMatch: ['**/tests/**/*.test.js'],
   collectCoverageFrom: ['src/**/*.js'],
   coverageThreshold: {
-    global: { lines: 80, functions: 80, branches: 80, statements: 80 },
+    global: {
+      lines: 80,
+      functions: 80,
+      branches: 80,
+      statements: 80,
+    },
   },
 };

--- a/backend/prisma/migrations/20240101000000_create_users/migration.sql
+++ b/backend/prisma/migrations/20240101000000_create_users/migration.sql
@@ -10,3 +10,6 @@ CREATE TABLE "User" (
 
 -- CreateIndex
 CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE INDEX "User_email_idx" ON "User"("email");

--- a/backend/prisma/migrations/20240101000000_create_users/migration.sql
+++ b/backend/prisma/migrations/20240101000000_create_users/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE INDEX "User_email_idx" ON "User"("email");

--- a/backend/prisma/migrations/20240101000000_create_users/migration.sql
+++ b/backend/prisma/migrations/20240101000000_create_users/migration.sql
@@ -10,6 +10,3 @@ CREATE TABLE "User" (
 
 -- CreateIndex
 CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
-
--- CreateIndex
-CREATE INDEX "User_email_idx" ON "User"("email");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,6 +12,4 @@ model User {
   email        String   @unique
   passwordHash String
   createdAt    DateTime @default(now())
-
-  @@index([email])
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id           String   @id @default(cuid())
+  email        String   @unique
+  passwordHash String
+  createdAt    DateTime @default(now())
+
+  @@index([email])
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,4 +12,6 @@ model User {
   email        String   @unique
   passwordHash String
   createdAt    DateTime @default(now())
+
+  @@index([email])
 }

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,22 +1,12 @@
 const express = require('express');
 const healthRouter = require('./routes/health');
+const authRouter = require('./routes/auth');
 
 const app = express();
 
 app.use(express.json());
 
-// Mount health-check route
 app.use('/', healthRouter);
-
-// 404 handler
-app.use((req, res) => {
-  res.status(404).json({ error: 'Not Found' });
-});
-
-// Global error handler
-app.use((err, req, res, next) => {
-  console.error(err);
-  res.status(500).json({ error: 'Internal Server Error' });
-});
+app.use('/api/auth', authRouter);
 
 module.exports = app;

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,12 +3,9 @@ const healthRouter = require('./routes/health');
 const authRouter = require('./routes/auth');
 
 const app = express();
-
 app.use(express.json());
 
 app.use('/', healthRouter);
 app.use('/api/auth', authRouter);
-
-app.use((req, res) => res.status(404).json({ error: 'Not found' }));
 
 module.exports = app;

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,6 +3,7 @@ const healthRouter = require('./routes/health');
 const authRouter = require('./routes/auth');
 
 const app = express();
+
 app.use(express.json());
 
 app.use('/', healthRouter);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -9,4 +9,6 @@ app.use(express.json());
 app.use('/', healthRouter);
 app.use('/api/auth', authRouter);
 
+app.use((req, res) => res.status(404).json({ error: 'Not found' }));
+
 module.exports = app;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,7 @@
+const app = require('./app');
+
+const PORT = process.env.PORT || 3000;
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/src/lib/prisma.js
+++ b/backend/src/lib/prisma.js
@@ -1,0 +1,5 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+module.exports = prisma;

--- a/backend/src/lib/prisma.js
+++ b/backend/src/lib/prisma.js
@@ -1,5 +1,9 @@
 const { PrismaClient } = require('@prisma/client');
 
-const prisma = new PrismaClient();
+const prisma = global.__prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  global.__prisma = prisma;
+}
 
 module.exports = prisma;

--- a/backend/src/lib/prisma.js
+++ b/backend/src/lib/prisma.js
@@ -1,9 +1,6 @@
 const { PrismaClient } = require('@prisma/client');
 
-const prisma = global.__prisma || new PrismaClient();
-
-if (process.env.NODE_ENV !== 'production') {
-  global.__prisma = prisma;
-}
+const prisma = global.__prisma ?? new PrismaClient();
+if (process.env.NODE_ENV !== 'production') global.__prisma = prisma;
 
 module.exports = prisma;

--- a/backend/src/lib/prisma.js
+++ b/backend/src/lib/prisma.js
@@ -1,6 +1,9 @@
 const { PrismaClient } = require('@prisma/client');
 
-const prisma = global.__prisma ?? new PrismaClient();
-if (process.env.NODE_ENV !== 'production') global.__prisma = prisma;
+const prisma = global.__prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  global.__prisma = prisma;
+}
 
 module.exports = prisma;

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,21 @@
+const jwt = require('jsonwebtoken');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Missing or invalid authorization header' });
+  }
+
+  const token = authHeader.slice(7);
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch {
+    return res.status(401).json({ error: 'Invalid or expired token' });
+  }
+}
+
+module.exports = authMiddleware;

--- a/backend/src/middleware/authenticate.js
+++ b/backend/src/middleware/authenticate.js
@@ -1,7 +1,7 @@
 const jwt = require('jsonwebtoken');
 const prisma = require('../lib/prisma');
 
-module.exports = async function authenticate(req, res, next) {
+async function authenticate(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'Missing or invalid authorization header' });
@@ -11,12 +11,12 @@ module.exports = async function authenticate(req, res, next) {
   try {
     const payload = jwt.verify(token, process.env.JWT_SECRET);
     const user = await prisma.user.findUnique({ where: { id: payload.sub } });
-    if (!user) {
-      return res.status(401).json({ error: 'User not found' });
-    }
+    if (!user) return res.status(401).json({ error: 'User not found' });
     req.user = user;
     next();
   } catch (err) {
     return res.status(401).json({ error: 'Invalid or expired token' });
   }
-};
+}
+
+module.exports = authenticate;

--- a/backend/src/middleware/authenticate.js
+++ b/backend/src/middleware/authenticate.js
@@ -1,7 +1,7 @@
 const jwt = require('jsonwebtoken');
 const prisma = require('../lib/prisma');
 
-async function authenticate(req, res, next) {
+module.exports = async function authenticate(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'Missing or invalid authorization header' });
@@ -11,12 +11,12 @@ async function authenticate(req, res, next) {
   try {
     const payload = jwt.verify(token, process.env.JWT_SECRET);
     const user = await prisma.user.findUnique({ where: { id: payload.sub } });
-    if (!user) return res.status(401).json({ error: 'User not found' });
+    if (!user) {
+      return res.status(401).json({ error: 'User not found' });
+    }
     req.user = user;
     next();
   } catch (err) {
     return res.status(401).json({ error: 'Invalid or expired token' });
   }
-}
-
-module.exports = authenticate;
+};

--- a/backend/src/middleware/authenticate.js
+++ b/backend/src/middleware/authenticate.js
@@ -1,0 +1,22 @@
+const jwt = require('jsonwebtoken');
+const prisma = require('../lib/prisma');
+
+module.exports = async function authenticate(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Missing or invalid authorization header' });
+  }
+
+  const token = authHeader.slice(7);
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await prisma.user.findUnique({ where: { id: payload.sub } });
+    if (!user) {
+      return res.status(401).json({ error: 'User not found' });
+    }
+    req.user = user;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid or expired token' });
+  }
+};

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -3,100 +3,79 @@ const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const { body, validationResult } = require('express-validator');
 const prisma = require('../lib/prisma');
-const authMiddleware = require('../middleware/auth');
+const authenticate = require('../middleware/authenticate');
 
 const router = express.Router();
-const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
 const SALT_ROUNDS = 10;
 
-const validateRegister = [
-  body('email').isEmail().normalizeEmail().withMessage('Valid email required'),
-  body('password').isLength({ min: 8 }).withMessage('Password must be at least 8 characters'),
-];
+const signToken = (userId) =>
+  jwt.sign({ sub: userId }, process.env.JWT_SECRET, { expiresIn: '24h' });
 
-const validateLogin = [
-  body('email').isEmail().normalizeEmail().withMessage('Valid email required'),
-  body('password').notEmpty().withMessage('Password required'),
-];
-
-function handleValidation(req, res) {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    res.status(400).json({ errors: errors.array() });
-    return false;
-  }
-  return true;
-}
-
-function signToken(user) {
-  return jwt.sign(
-    { sub: user.id, email: user.email },
-    JWT_SECRET,
-    { expiresIn: '24h' }
-  );
-}
-
-router.post('/register', validateRegister, async (req, res) => {
-  if (!handleValidation(req, res)) return;
-
-  const { email, password } = req.body;
-  try {
-    const existing = await prisma.user.findUnique({ where: { email } });
-    if (existing) {
-      return res.status(409).json({ error: 'Email already in use' });
+router.post(
+  '/register',
+  [
+    body('email').isEmail().normalizeEmail(),
+    body('password').isLength({ min: 8 }),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
     }
 
-    const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
-    const user = await prisma.user.create({
-      data: { email, passwordHash },
-      select: { id: true, email: true, createdAt: true },
-    });
+    const { email, password } = req.body;
+    try {
+      const existing = await prisma.user.findUnique({ where: { email } });
+      if (existing) return res.status(409).json({ error: 'Email already in use' });
 
-    const token = signToken(user);
-    return res.status(201).json({ token, user });
-  } catch (err) {
-    return res.status(500).json({ error: 'Internal server error' });
+      const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+      const user = await prisma.user.create({
+        data: { email, passwordHash },
+        select: { id: true, email: true, createdAt: true },
+      });
+
+      const token = signToken(user.id);
+      return res.status(201).json({ user, token });
+    } catch (err) {
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   }
-});
+);
 
-router.post('/login', validateLogin, async (req, res) => {
-  if (!handleValidation(req, res)) return;
-
-  const { email, password } = req.body;
-  try {
-    const user = await prisma.user.findUnique({ where: { email } });
-    if (!user) {
-      return res.status(401).json({ error: 'Invalid credentials' });
+router.post(
+  '/login',
+  [
+    body('email').isEmail().normalizeEmail(),
+    body('password').notEmpty(),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
     }
 
-    const valid = await bcrypt.compare(password, user.passwordHash);
-    if (!valid) {
-      return res.status(401).json({ error: 'Invalid credentials' });
-    }
+    const { email, password } = req.body;
+    try {
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user) return res.status(401).json({ error: 'Invalid credentials' });
 
-    const token = signToken(user);
-    return res.status(200).json({
-      token,
-      user: { id: user.id, email: user.email, createdAt: user.createdAt },
-    });
-  } catch {
-    return res.status(500).json({ error: 'Internal server error' });
-  }
-});
+      const valid = await bcrypt.compare(password, user.passwordHash);
+      if (!valid) return res.status(401).json({ error: 'Invalid credentials' });
 
-router.get('/me', authMiddleware, async (req, res) => {
-  try {
-    const user = await prisma.user.findUnique({
-      where: { id: req.user.sub },
-      select: { id: true, email: true, createdAt: true },
-    });
-    if (!user) {
-      return res.status(401).json({ error: 'User not found' });
+      const token = signToken(user.id);
+      return res.status(200).json({
+        token,
+        user: { id: user.id, email: user.email, createdAt: user.createdAt },
+      });
+    } catch (err) {
+      return res.status(500).json({ error: 'Internal server error' });
     }
-    return res.status(200).json({ user });
-  } catch {
-    return res.status(500).json({ error: 'Internal server error' });
   }
+);
+
+router.get('/me', authenticate, (req, res) => {
+  const { id, email, createdAt } = req.user;
+  return res.status(200).json({ id, email, createdAt });
 });
 
 module.exports = router;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,88 +1,102 @@
 const express = require('express');
-const { body, validationResult } = require('express-validator');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
+const { body, validationResult } = require('express-validator');
 const prisma = require('../lib/prisma');
-const authenticate = require('../middleware/authenticate');
+const authMiddleware = require('../middleware/auth');
 
 const router = express.Router();
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
 const SALT_ROUNDS = 10;
 
-function signToken(userId) {
-  return jwt.sign({ sub: userId }, process.env.JWT_SECRET, { expiresIn: '24h' });
+const validateRegister = [
+  body('email').isEmail().normalizeEmail().withMessage('Valid email required'),
+  body('password').isLength({ min: 8 }).withMessage('Password must be at least 8 characters'),
+];
+
+const validateLogin = [
+  body('email').isEmail().normalizeEmail().withMessage('Valid email required'),
+  body('password').notEmpty().withMessage('Password required'),
+];
+
+function handleValidation(req, res) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ errors: errors.array() });
+    return false;
+  }
+  return true;
 }
 
-router.post(
-  '/register',
-  [
-    body('email').isEmail().normalizeEmail(),
-    body('password').isLength({ min: 8 }),
-  ],
-  async (req, res) => {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res.status(400).json({ errors: errors.array() });
+function signToken(user) {
+  return jwt.sign(
+    { sub: user.id, email: user.email },
+    JWT_SECRET,
+    { expiresIn: '24h' }
+  );
+}
+
+router.post('/register', validateRegister, async (req, res) => {
+  if (!handleValidation(req, res)) return;
+
+  const { email, password } = req.body;
+  try {
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return res.status(409).json({ error: 'Email already in use' });
     }
 
-    const { email, password } = req.body;
-    try {
-      const existing = await prisma.user.findUnique({ where: { email } });
-      if (existing) {
-        return res.status(409).json({ error: 'Email already in use' });
-      }
+    const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+    const user = await prisma.user.create({
+      data: { email, passwordHash },
+      select: { id: true, email: true, createdAt: true },
+    });
 
-      const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
-      const user = await prisma.user.create({
-        data: { email, passwordHash },
-        select: { id: true, email: true, createdAt: true },
-      });
-
-      const token = signToken(user.id);
-      return res.status(201).json({ user, token });
-    } catch (err) {
-      return res.status(500).json({ error: 'Internal server error' });
-    }
+    const token = signToken(user);
+    return res.status(201).json({ token, user });
+  } catch (err) {
+    return res.status(500).json({ error: 'Internal server error' });
   }
-);
+});
 
-router.post(
-  '/login',
-  [
-    body('email').isEmail().normalizeEmail(),
-    body('password').notEmpty(),
-  ],
-  async (req, res) => {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res.status(400).json({ errors: errors.array() });
+router.post('/login', validateLogin, async (req, res) => {
+  if (!handleValidation(req, res)) return;
+
+  const { email, password } = req.body;
+  try {
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid credentials' });
     }
 
-    const { email, password } = req.body;
-    try {
-      const user = await prisma.user.findUnique({ where: { email } });
-      if (!user) {
-        return res.status(401).json({ error: 'Invalid credentials' });
-      }
-
-      const valid = await bcrypt.compare(password, user.passwordHash);
-      if (!valid) {
-        return res.status(401).json({ error: 'Invalid credentials' });
-      }
-
-      const token = signToken(user.id);
-      return res.status(200).json({
-        token,
-        user: { id: user.id, email: user.email, createdAt: user.createdAt },
-      });
-    } catch (err) {
-      return res.status(500).json({ error: 'Internal server error' });
+    const valid = await bcrypt.compare(password, user.passwordHash);
+    if (!valid) {
+      return res.status(401).json({ error: 'Invalid credentials' });
     }
+
+    const token = signToken(user);
+    return res.status(200).json({
+      token,
+      user: { id: user.id, email: user.email, createdAt: user.createdAt },
+    });
+  } catch {
+    return res.status(500).json({ error: 'Internal server error' });
   }
-);
+});
 
-router.get('/me', authenticate, (req, res) => {
-  const { id, email, createdAt } = req.user;
-  return res.status(200).json({ id, email, createdAt });
+router.get('/me', authMiddleware, async (req, res) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.sub },
+      select: { id: true, email: true, createdAt: true },
+    });
+    if (!user) {
+      return res.status(401).json({ error: 'User not found' });
+    }
+    return res.status(200).json({ user });
+  } catch {
+    return res.status(500).json({ error: 'Internal server error' });
+  }
 });
 
 module.exports = router;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -8,14 +8,15 @@ const authenticate = require('../middleware/authenticate');
 const router = express.Router();
 const SALT_ROUNDS = 10;
 
-const signToken = (userId) =>
-  jwt.sign({ sub: userId }, process.env.JWT_SECRET, { expiresIn: '24h' });
+function signToken(userId) {
+  return jwt.sign({ sub: userId }, process.env.JWT_SECRET, { expiresIn: '24h' });
+}
 
 router.post(
   '/register',
   [
-    body('email').isEmail().normalizeEmail(),
-    body('password').isLength({ min: 8 }),
+    body('email').isEmail().normalizeEmail().withMessage('Valid email required'),
+    body('password').isLength({ min: 8 }).withMessage('Password must be at least 8 characters'),
   ],
   async (req, res) => {
     const errors = validationResult(req);
@@ -24,9 +25,12 @@ router.post(
     }
 
     const { email, password } = req.body;
+
     try {
       const existing = await prisma.user.findUnique({ where: { email } });
-      if (existing) return res.status(409).json({ error: 'Email already in use' });
+      if (existing) {
+        return res.status(409).json({ error: 'Email already in use' });
+      }
 
       const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
       const user = await prisma.user.create({
@@ -45,8 +49,8 @@ router.post(
 router.post(
   '/login',
   [
-    body('email').isEmail().normalizeEmail(),
-    body('password').notEmpty(),
+    body('email').isEmail().normalizeEmail().withMessage('Valid email required'),
+    body('password').notEmpty().withMessage('Password required'),
   ],
   async (req, res) => {
     const errors = validationResult(req);
@@ -55,12 +59,17 @@ router.post(
     }
 
     const { email, password } = req.body;
+
     try {
       const user = await prisma.user.findUnique({ where: { email } });
-      if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+      if (!user) {
+        return res.status(401).json({ error: 'Invalid credentials' });
+      }
 
       const valid = await bcrypt.compare(password, user.passwordHash);
-      if (!valid) return res.status(401).json({ error: 'Invalid credentials' });
+      if (!valid) {
+        return res.status(401).json({ error: 'Invalid credentials' });
+      }
 
       const token = signToken(user.id);
       return res.status(200).json({
@@ -75,7 +84,7 @@ router.post(
 
 router.get('/me', authenticate, (req, res) => {
   const { id, email, createdAt } = req.user;
-  return res.status(200).json({ id, email, createdAt });
+  return res.status(200).json({ user: { id, email, createdAt } });
 });
 
 module.exports = router;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,88 @@
+const express = require('express');
+const { body, validationResult } = require('express-validator');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const prisma = require('../lib/prisma');
+const authenticate = require('../middleware/authenticate');
+
+const router = express.Router();
+const SALT_ROUNDS = 10;
+
+function signToken(userId) {
+  return jwt.sign({ sub: userId }, process.env.JWT_SECRET, { expiresIn: '24h' });
+}
+
+router.post(
+  '/register',
+  [
+    body('email').isEmail().normalizeEmail(),
+    body('password').isLength({ min: 8 }),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { email, password } = req.body;
+    try {
+      const existing = await prisma.user.findUnique({ where: { email } });
+      if (existing) {
+        return res.status(409).json({ error: 'Email already in use' });
+      }
+
+      const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+      const user = await prisma.user.create({
+        data: { email, passwordHash },
+        select: { id: true, email: true, createdAt: true },
+      });
+
+      const token = signToken(user.id);
+      return res.status(201).json({ user, token });
+    } catch (err) {
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+);
+
+router.post(
+  '/login',
+  [
+    body('email').isEmail().normalizeEmail(),
+    body('password').notEmpty(),
+  ],
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { email, password } = req.body;
+    try {
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user) {
+        return res.status(401).json({ error: 'Invalid credentials' });
+      }
+
+      const valid = await bcrypt.compare(password, user.passwordHash);
+      if (!valid) {
+        return res.status(401).json({ error: 'Invalid credentials' });
+      }
+
+      const token = signToken(user.id);
+      return res.status(200).json({
+        token,
+        user: { id: user.id, email: user.email, createdAt: user.createdAt },
+      });
+    } catch (err) {
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  }
+);
+
+router.get('/me', authenticate, (req, res) => {
+  const { id, email, createdAt } = req.user;
+  return res.status(200).json({ id, email, createdAt });
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,7 +1,6 @@
 const app = require('./app');
 
 const PORT = process.env.PORT || 3000;
-
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,5 +3,5 @@ const app = require('./app');
 const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
+  console.log(`Server running on port ${PORT}`);
 });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,6 +1,7 @@
 const app = require('./app');
 
 const PORT = process.env.PORT || 3000;
+
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -1,0 +1,168 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const app = require('../src/app');
+const prisma = require('../src/lib/prisma');
+
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../src/lib/prisma', () => ({
+  user: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /api/auth/register', () => {
+  it('returns 400 for invalid email', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'not-an-email', password: 'password123' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for short password', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'test@example.com', password: 'short' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 if email already in use', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: '1', email: 'test@example.com' });
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'test@example.com', password: 'password123' });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('Email already in use');
+  });
+
+  it('creates user and returns 201 with token', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+    prisma.user.create.mockResolvedValue({
+      id: 'abc123',
+      email: 'test@example.com',
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'test@example.com', password: 'password123' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.token).toBeDefined();
+    expect(res.body.user.email).toBe('test@example.com');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'test@example.com', password: 'password123' });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/auth/login', () => {
+  it('returns 400 for missing fields', async () => {
+    const res = await request(app).post('/api/auth/login').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 if user not found', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'nobody@example.com', password: 'password123' });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid credentials');
+  });
+
+  it('returns 401 for wrong password', async () => {
+    const passwordHash = await bcrypt.hash('correctpassword', 10);
+    prisma.user.findUnique.mockResolvedValue({
+      id: '1',
+      email: 'test@example.com',
+      passwordHash,
+    });
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com', password: 'wrongpassword' });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid credentials');
+  });
+
+  it('returns 200 with token on valid credentials', async () => {
+    const passwordHash = await bcrypt.hash('password123', 10);
+    prisma.user.findUnique.mockResolvedValue({
+      id: 'abc123',
+      email: 'test@example.com',
+      passwordHash,
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com', password: 'password123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+    expect(res.body.user.email).toBe('test@example.com');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com', password: 'password123' });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('GET /api/auth/me', () => {
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/api/auth/me');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with invalid token', async () => {
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', 'Bearer invalidtoken');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 if user no longer exists', async () => {
+    const token = jwt.sign({ sub: 'ghost' }, process.env.JWT_SECRET, { expiresIn: '1h' });
+    prisma.user.findUnique.mockResolvedValue(null);
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('User not found');
+  });
+
+  it('returns 200 with user data for valid token', async () => {
+    const user = {
+      id: 'abc123',
+      email: 'test@example.com',
+      passwordHash: 'hash',
+      createdAt: new Date().toISOString(),
+    };
+    const token = jwt.sign({ sub: user.id }, process.env.JWT_SECRET, { expiresIn: '1h' });
+    prisma.user.findUnique.mockResolvedValue(user);
+
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.email).toBe('test@example.com');
+    expect(res.body.passwordHash).toBeUndefined();
+  });
+});

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -4,23 +4,6 @@ const jwt = require('jsonwebtoken');
 const app = require('../src/app');
 const prisma = require('../src/lib/prisma');
 
-process.env.JWT_SECRET = 'test-secret';
-
-const mockUser = {
-  id: 'user-1',
-  email: 'test@example.com',
-  passwordHash: '',
-  createdAt: new Date(),
-};
-
-beforeAll(async () => {
-  mockUser.passwordHash = await bcrypt.hash('password123', 10);
-});
-
-beforeEach(() => {
-  jest.clearAllMocks();
-});
-
 jest.mock('../src/lib/prisma', () => ({
   user: {
     findUnique: jest.fn(),
@@ -28,131 +11,99 @@ jest.mock('../src/lib/prisma', () => ({
   },
 }));
 
+const JWT_SECRET = 'test-secret';
+
+beforeAll(() => {
+  process.env.JWT_SECRET = JWT_SECRET;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('POST /api/auth/register', () => {
-  it('creates a user and returns 201 with token', async () => {
+  it('returns 400 if email is invalid', async () => {
+    const res = await request(app).post('/api/auth/register').send({ email: 'bad', password: 'password123' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 if password too short', async () => {
+    const res = await request(app).post('/api/auth/register').send({ email: 'a@b.com', password: 'short' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 if email already taken', async () => {
+    prisma.user.findUnique.mockResolvedValue({ id: '1', email: 'a@b.com' });
+    const res = await request(app).post('/api/auth/register').send({ email: 'a@b.com', password: 'password123' });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/email already in use/i);
+  });
+
+  it('returns 201 with user and token on success', async () => {
     prisma.user.findUnique.mockResolvedValue(null);
-    prisma.user.create.mockResolvedValue({
-      id: 'user-1',
-      email: 'new@example.com',
-      createdAt: new Date(),
-    });
+    const created = { id: 'cuid1', email: 'a@b.com', createdAt: new Date().toISOString() };
+    prisma.user.create.mockResolvedValue(created);
 
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'new@example.com', password: 'password123' });
-
+    const res = await request(app).post('/api/auth/register').send({ email: 'a@b.com', password: 'password123' });
     expect(res.status).toBe(201);
     expect(res.body.token).toBeDefined();
-    expect(res.body.user.email).toBe('new@example.com');
+    expect(res.body.user.email).toBe('a@b.com');
     expect(res.body.user.passwordHash).toBeUndefined();
   });
 
-  it('returns 409 when email already exists', async () => {
-    prisma.user.findUnique.mockResolvedValue(mockUser);
-
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'test@example.com', password: 'password123' });
-
-    expect(res.status).toBe(409);
-    expect(res.body.error).toMatch(/already in use/i);
-  });
-
-  it('returns 400 for invalid email', async () => {
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'not-an-email', password: 'password123' });
-
-    expect(res.status).toBe(400);
-  });
-
-  it('returns 400 for short password', async () => {
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'valid@example.com', password: 'short' });
-
-    expect(res.status).toBe(400);
-  });
-
-  it('returns 500 on unexpected prisma error', async () => {
-    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
-
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'err@example.com', password: 'password123' });
-
+  it('returns 500 on unexpected error', async () => {
+    prisma.user.findUnique.mockRejectedValue(new Error('db error'));
+    const res = await request(app).post('/api/auth/register').send({ email: 'a@b.com', password: 'password123' });
     expect(res.status).toBe(500);
   });
 });
 
 describe('POST /api/auth/login', () => {
-  it('returns 200 with token on valid credentials', async () => {
-    prisma.user.findUnique.mockResolvedValue(mockUser);
-
-    const res = await request(app)
-      .post('/api/auth/login')
-      .send({ email: 'test@example.com', password: 'password123' });
-
-    expect(res.status).toBe(200);
-    expect(res.body.token).toBeDefined();
-    const payload = jwt.verify(res.body.token, 'test-secret');
-    expect(payload.sub).toBe('user-1');
+  it('returns 400 if email is invalid', async () => {
+    const res = await request(app).post('/api/auth/login').send({ email: 'bad', password: 'pass' });
+    expect(res.status).toBe(400);
   });
 
-  it('returns 401 for unknown email', async () => {
+  it('returns 400 if password missing', async () => {
+    const res = await request(app).post('/api/auth/login').send({ email: 'a@b.com', password: '' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 if user not found', async () => {
     prisma.user.findUnique.mockResolvedValue(null);
-
-    const res = await request(app)
-      .post('/api/auth/login')
-      .send({ email: 'nobody@example.com', password: 'password123' });
-
+    const res = await request(app).post('/api/auth/login').send({ email: 'a@b.com', password: 'password123' });
     expect(res.status).toBe(401);
     expect(res.body.error).toMatch(/invalid credentials/i);
   });
 
-  it('returns 401 for wrong password', async () => {
-    prisma.user.findUnique.mockResolvedValue(mockUser);
-
-    const res = await request(app)
-      .post('/api/auth/login')
-      .send({ email: 'test@example.com', password: 'wrongpassword' });
-
+  it('returns 401 if password wrong', async () => {
+    const hash = await bcrypt.hash('correct', 10);
+    prisma.user.findUnique.mockResolvedValue({ id: '1', email: 'a@b.com', passwordHash: hash });
+    const res = await request(app).post('/api/auth/login').send({ email: 'a@b.com', password: 'wrong' });
     expect(res.status).toBe(401);
   });
 
-  it('returns 400 for missing fields', async () => {
-    const res = await request(app)
-      .post('/api/auth/login')
-      .send({ email: 'test@example.com' });
-
-    expect(res.status).toBe(400);
+  it('returns 200 with token on valid credentials', async () => {
+    const hash = await bcrypt.hash('password123', 10);
+    prisma.user.findUnique.mockResolvedValue({ id: 'cuid1', email: 'a@b.com', passwordHash: hash, createdAt: new Date() });
+    const res = await request(app).post('/api/auth/login').send({ email: 'a@b.com', password: 'password123' });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+    const payload = jwt.verify(res.body.token, JWT_SECRET);
+    expect(payload.sub).toBe('cuid1');
   });
 
-  it('returns 500 on DB error', async () => {
-    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
-
-    const res = await request(app)
-      .post('/api/auth/login')
-      .send({ email: 'test@example.com', password: 'password123' });
-
+  it('returns 500 on unexpected error', async () => {
+    prisma.user.findUnique.mockRejectedValue(new Error('db error'));
+    const res = await request(app).post('/api/auth/login').send({ email: 'a@b.com', password: 'password123' });
     expect(res.status).toBe(500);
   });
 });
 
 describe('GET /api/auth/me', () => {
-  const validToken = () => jwt.sign({ sub: 'user-1' }, 'test-secret', { expiresIn: '1h' });
-
-  it('returns 200 with user data for valid token', async () => {
-    prisma.user.findUnique.mockResolvedValue(mockUser);
-
-    const res = await request(app)
-      .get('/api/auth/me')
-      .set('Authorization', `Bearer ${validToken()}`);
-
-    expect(res.status).toBe(200);
-    expect(res.body.email).toBe('test@example.com');
-    expect(res.body.passwordHash).toBeUndefined();
-  });
+  function makeToken(userId) {
+    return jwt.sign({ sub: userId }, JWT_SECRET, { expiresIn: '1h' });
+  }
 
   it('returns 401 with no token', async () => {
     const res = await request(app).get('/api/auth/me');
@@ -160,30 +111,24 @@ describe('GET /api/auth/me', () => {
   });
 
   it('returns 401 with malformed token', async () => {
-    const res = await request(app)
-      .get('/api/auth/me')
-      .set('Authorization', 'Bearer invalid.token.here');
+    const res = await request(app).get('/api/auth/me').set('Authorization', 'Bearer badtoken');
     expect(res.status).toBe(401);
   });
 
-  it('returns 401 when user no longer exists', async () => {
+  it('returns 401 if user no longer exists', async () => {
     prisma.user.findUnique.mockResolvedValue(null);
-
-    const res = await request(app)
-      .get('/api/auth/me')
-      .set('Authorization', `Bearer ${validToken()}`);
-
+    const token = makeToken('ghost');
+    const res = await request(app).get('/api/auth/me').set('Authorization', `Bearer ${token}`);
     expect(res.status).toBe(401);
   });
 
-  it('returns 401 for expired token', async () => {
-    const expiredToken = jwt.sign({ sub: 'user-1' }, 'test-secret', { expiresIn: '0s' });
-    await new Promise((r) => setTimeout(r, 10));
-
-    const res = await request(app)
-      .get('/api/auth/me')
-      .set('Authorization', `Bearer ${expiredToken}`);
-
-    expect(res.status).toBe(401);
+  it('returns 200 with user data on valid token', async () => {
+    const user = { id: 'cuid1', email: 'a@b.com', passwordHash: 'h', createdAt: new Date() };
+    prisma.user.findUnique.mockResolvedValue(user);
+    const token = makeToken('cuid1');
+    const res = await request(app).get('/api/auth/me').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.id).toBe('cuid1');
+    expect(res.body.user.passwordHash).toBeUndefined();
   });
 });

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -4,8 +4,6 @@ const jwt = require('jsonwebtoken');
 const app = require('../src/app');
 const prisma = require('../src/lib/prisma');
 
-process.env.JWT_SECRET = 'test-secret';
-
 jest.mock('../src/lib/prisma', () => ({
   user: {
     findUnique: jest.fn(),
@@ -13,40 +11,30 @@ jest.mock('../src/lib/prisma', () => ({
   },
 }));
 
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+const mockUser = {
+  id: 'cuid123',
+  email: 'test@example.com',
+  passwordHash: '',
+  createdAt: new Date('2024-01-01'),
+};
+
+beforeAll(async () => {
+  mockUser.passwordHash = await bcrypt.hash('password123', 10);
+});
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
 describe('POST /api/auth/register', () => {
-  it('returns 400 for invalid email', async () => {
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'not-an-email', password: 'password123' });
-    expect(res.status).toBe(400);
-  });
-
-  it('returns 400 for short password', async () => {
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'test@example.com', password: 'short' });
-    expect(res.status).toBe(400);
-  });
-
-  it('returns 409 if email already in use', async () => {
-    prisma.user.findUnique.mockResolvedValue({ id: '1', email: 'test@example.com' });
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'test@example.com', password: 'password123' });
-    expect(res.status).toBe(409);
-    expect(res.body.error).toBe('Email already in use');
-  });
-
-  it('creates user and returns 201 with token', async () => {
+  test('201 — creates user with hashed password', async () => {
     prisma.user.findUnique.mockResolvedValue(null);
     prisma.user.create.mockResolvedValue({
-      id: 'abc123',
-      email: 'test@example.com',
-      createdAt: new Date().toISOString(),
+      id: mockUser.id,
+      email: mockUser.email,
+      createdAt: mockUser.createdAt,
     });
 
     const res = await request(app)
@@ -56,55 +44,48 @@ describe('POST /api/auth/register', () => {
     expect(res.status).toBe(201);
     expect(res.body.token).toBeDefined();
     expect(res.body.user.email).toBe('test@example.com');
+    expect(res.body.user.passwordHash).toBeUndefined();
   });
 
-  it('returns 500 on unexpected error', async () => {
-    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
+  test('409 — duplicate email', async () => {
+    prisma.user.findUnique.mockResolvedValue(mockUser);
+
     const res = await request(app)
       .post('/api/auth/register')
       .send({ email: 'test@example.com', password: 'password123' });
-    expect(res.status).toBe(500);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('Email already in use');
+  });
+
+  test('400 — invalid email', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'not-an-email', password: 'password123' });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('400 — short password', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'test@example.com', password: 'short' });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('400 — missing fields', async () => {
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({});
+
+    expect(res.status).toBe(400);
   });
 });
 
 describe('POST /api/auth/login', () => {
-  it('returns 400 for missing fields', async () => {
-    const res = await request(app).post('/api/auth/login').send({});
-    expect(res.status).toBe(400);
-  });
-
-  it('returns 401 if user not found', async () => {
-    prisma.user.findUnique.mockResolvedValue(null);
-    const res = await request(app)
-      .post('/api/auth/login')
-      .send({ email: 'nobody@example.com', password: 'password123' });
-    expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Invalid credentials');
-  });
-
-  it('returns 401 for wrong password', async () => {
-    const passwordHash = await bcrypt.hash('correctpassword', 10);
-    prisma.user.findUnique.mockResolvedValue({
-      id: '1',
-      email: 'test@example.com',
-      passwordHash,
-    });
-
-    const res = await request(app)
-      .post('/api/auth/login')
-      .send({ email: 'test@example.com', password: 'wrongpassword' });
-    expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Invalid credentials');
-  });
-
-  it('returns 200 with token on valid credentials', async () => {
-    const passwordHash = await bcrypt.hash('password123', 10);
-    prisma.user.findUnique.mockResolvedValue({
-      id: 'abc123',
-      email: 'test@example.com',
-      passwordHash,
-      createdAt: new Date().toISOString(),
-    });
+  test('200 — valid credentials return JWT', async () => {
+    prisma.user.findUnique.mockResolvedValue(mockUser);
 
     const res = await request(app)
       .post('/api/auth/login')
@@ -112,57 +93,100 @@ describe('POST /api/auth/login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.token).toBeDefined();
-    expect(res.body.user.email).toBe('test@example.com');
+    const payload = jwt.verify(res.body.token, JWT_SECRET);
+    expect(payload.sub).toBe(mockUser.id);
+    expect(payload.email).toBe(mockUser.email);
   });
 
-  it('returns 500 on unexpected error', async () => {
-    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
+  test('401 — wrong password', async () => {
+    prisma.user.findUnique.mockResolvedValue(mockUser);
+
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'test@example.com', password: 'password123' });
-    expect(res.status).toBe(500);
+      .send({ email: 'test@example.com', password: 'wrongpassword' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid credentials');
+  });
+
+  test('401 — user not found', async () => {
+    prisma.user.findUnique.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'nobody@example.com', password: 'password123' });
+
+    expect(res.status).toBe(401);
+  });
+
+  test('400 — missing email', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ password: 'password123' });
+
+    expect(res.status).toBe(400);
   });
 });
 
 describe('GET /api/auth/me', () => {
-  it('returns 401 without token', async () => {
+  function makeToken(overrides = {}) {
+    return jwt.sign(
+      { sub: mockUser.id, email: mockUser.email, ...overrides },
+      JWT_SECRET,
+      { expiresIn: '1h' }
+    );
+  }
+
+  test('200 — returns user data with valid token', async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: mockUser.id,
+      email: mockUser.email,
+      createdAt: mockUser.createdAt,
+    });
+
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.email).toBe(mockUser.email);
+    expect(res.body.user.passwordHash).toBeUndefined();
+  });
+
+  test('401 — no token', async () => {
     const res = await request(app).get('/api/auth/me');
     expect(res.status).toBe(401);
   });
 
-  it('returns 401 with invalid token', async () => {
+  test('401 — invalid token', async () => {
     const res = await request(app)
       .get('/api/auth/me')
       .set('Authorization', 'Bearer invalidtoken');
+
     expect(res.status).toBe(401);
   });
 
-  it('returns 401 if user no longer exists', async () => {
-    const token = jwt.sign({ sub: 'ghost' }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  test('401 — expired token', async () => {
+    const token = jwt.sign(
+      { sub: mockUser.id, email: mockUser.email },
+      JWT_SECRET,
+      { expiresIn: '-1s' }
+    );
+
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+  });
+
+  test('401 — user not found in db', async () => {
     prisma.user.findUnique.mockResolvedValue(null);
+
     const res = await request(app)
       .get('/api/auth/me')
-      .set('Authorization', `Bearer ${token}`);
+      .set('Authorization', `Bearer ${makeToken()}`);
+
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('User not found');
-  });
-
-  it('returns 200 with user data for valid token', async () => {
-    const user = {
-      id: 'abc123',
-      email: 'test@example.com',
-      passwordHash: 'hash',
-      createdAt: new Date().toISOString(),
-    };
-    const token = jwt.sign({ sub: user.id }, process.env.JWT_SECRET, { expiresIn: '1h' });
-    prisma.user.findUnique.mockResolvedValue(user);
-
-    const res = await request(app)
-      .get('/api/auth/me')
-      .set('Authorization', `Bearer ${token}`);
-
-    expect(res.status).toBe(200);
-    expect(res.body.email).toBe('test@example.com');
-    expect(res.body.passwordHash).toBeUndefined();
   });
 });

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -4,20 +4,13 @@ const jwt = require('jsonwebtoken');
 const app = require('../src/app');
 const prisma = require('../src/lib/prisma');
 
-jest.mock('../src/lib/prisma', () => ({
-  user: {
-    findUnique: jest.fn(),
-    create: jest.fn(),
-  },
-}));
-
-const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+process.env.JWT_SECRET = 'test-secret';
 
 const mockUser = {
-  id: 'cuid123',
+  id: 'user-1',
   email: 'test@example.com',
   passwordHash: '',
-  createdAt: new Date('2024-01-01'),
+  createdAt: new Date(),
 };
 
 beforeAll(async () => {
@@ -28,26 +21,33 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
+jest.mock('../src/lib/prisma', () => ({
+  user: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
 describe('POST /api/auth/register', () => {
-  test('201 — creates user with hashed password', async () => {
+  it('creates a user and returns 201 with token', async () => {
     prisma.user.findUnique.mockResolvedValue(null);
     prisma.user.create.mockResolvedValue({
-      id: mockUser.id,
-      email: mockUser.email,
-      createdAt: mockUser.createdAt,
+      id: 'user-1',
+      email: 'new@example.com',
+      createdAt: new Date(),
     });
 
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ email: 'test@example.com', password: 'password123' });
+      .send({ email: 'new@example.com', password: 'password123' });
 
     expect(res.status).toBe(201);
     expect(res.body.token).toBeDefined();
-    expect(res.body.user.email).toBe('test@example.com');
+    expect(res.body.user.email).toBe('new@example.com');
     expect(res.body.user.passwordHash).toBeUndefined();
   });
 
-  test('409 — duplicate email', async () => {
+  it('returns 409 when email already exists', async () => {
     prisma.user.findUnique.mockResolvedValue(mockUser);
 
     const res = await request(app)
@@ -55,10 +55,10 @@ describe('POST /api/auth/register', () => {
       .send({ email: 'test@example.com', password: 'password123' });
 
     expect(res.status).toBe(409);
-    expect(res.body.error).toBe('Email already in use');
+    expect(res.body.error).toMatch(/already in use/i);
   });
 
-  test('400 — invalid email', async () => {
+  it('returns 400 for invalid email', async () => {
     const res = await request(app)
       .post('/api/auth/register')
       .send({ email: 'not-an-email', password: 'password123' });
@@ -66,25 +66,27 @@ describe('POST /api/auth/register', () => {
     expect(res.status).toBe(400);
   });
 
-  test('400 — short password', async () => {
+  it('returns 400 for short password', async () => {
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ email: 'test@example.com', password: 'short' });
+      .send({ email: 'valid@example.com', password: 'short' });
 
     expect(res.status).toBe(400);
   });
 
-  test('400 — missing fields', async () => {
+  it('returns 500 on unexpected prisma error', async () => {
+    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
+
     const res = await request(app)
       .post('/api/auth/register')
-      .send({});
+      .send({ email: 'err@example.com', password: 'password123' });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(500);
   });
 });
 
 describe('POST /api/auth/login', () => {
-  test('200 — valid credentials return JWT', async () => {
+  it('returns 200 with token on valid credentials', async () => {
     prisma.user.findUnique.mockResolvedValue(mockUser);
 
     const res = await request(app)
@@ -93,23 +95,11 @@ describe('POST /api/auth/login', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.token).toBeDefined();
-    const payload = jwt.verify(res.body.token, JWT_SECRET);
-    expect(payload.sub).toBe(mockUser.id);
-    expect(payload.email).toBe(mockUser.email);
+    const payload = jwt.verify(res.body.token, 'test-secret');
+    expect(payload.sub).toBe('user-1');
   });
 
-  test('401 — wrong password', async () => {
-    prisma.user.findUnique.mockResolvedValue(mockUser);
-
-    const res = await request(app)
-      .post('/api/auth/login')
-      .send({ email: 'test@example.com', password: 'wrongpassword' });
-
-    expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Invalid credentials');
-  });
-
-  test('401 — user not found', async () => {
+  it('returns 401 for unknown email', async () => {
     prisma.user.findUnique.mockResolvedValue(null);
 
     const res = await request(app)
@@ -117,75 +107,82 @@ describe('POST /api/auth/login', () => {
       .send({ email: 'nobody@example.com', password: 'password123' });
 
     expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/invalid credentials/i);
   });
 
-  test('400 — missing email', async () => {
+  it('returns 401 for wrong password', async () => {
+    prisma.user.findUnique.mockResolvedValue(mockUser);
+
     const res = await request(app)
       .post('/api/auth/login')
-      .send({ password: 'password123' });
+      .send({ email: 'test@example.com', password: 'wrongpassword' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for missing fields', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com' });
 
     expect(res.status).toBe(400);
+  });
+
+  it('returns 500 on DB error', async () => {
+    prisma.user.findUnique.mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com', password: 'password123' });
+
+    expect(res.status).toBe(500);
   });
 });
 
 describe('GET /api/auth/me', () => {
-  function makeToken(overrides = {}) {
-    return jwt.sign(
-      { sub: mockUser.id, email: mockUser.email, ...overrides },
-      JWT_SECRET,
-      { expiresIn: '1h' }
-    );
-  }
+  const validToken = () => jwt.sign({ sub: 'user-1' }, 'test-secret', { expiresIn: '1h' });
 
-  test('200 — returns user data with valid token', async () => {
-    prisma.user.findUnique.mockResolvedValue({
-      id: mockUser.id,
-      email: mockUser.email,
-      createdAt: mockUser.createdAt,
-    });
+  it('returns 200 with user data for valid token', async () => {
+    prisma.user.findUnique.mockResolvedValue(mockUser);
 
     const res = await request(app)
       .get('/api/auth/me')
-      .set('Authorization', `Bearer ${makeToken()}`);
+      .set('Authorization', `Bearer ${validToken()}`);
 
     expect(res.status).toBe(200);
-    expect(res.body.user.email).toBe(mockUser.email);
-    expect(res.body.user.passwordHash).toBeUndefined();
+    expect(res.body.email).toBe('test@example.com');
+    expect(res.body.passwordHash).toBeUndefined();
   });
 
-  test('401 — no token', async () => {
+  it('returns 401 with no token', async () => {
     const res = await request(app).get('/api/auth/me');
     expect(res.status).toBe(401);
   });
 
-  test('401 — invalid token', async () => {
+  it('returns 401 with malformed token', async () => {
     const res = await request(app)
       .get('/api/auth/me')
-      .set('Authorization', 'Bearer invalidtoken');
-
+      .set('Authorization', 'Bearer invalid.token.here');
     expect(res.status).toBe(401);
   });
 
-  test('401 — expired token', async () => {
-    const token = jwt.sign(
-      { sub: mockUser.id, email: mockUser.email },
-      JWT_SECRET,
-      { expiresIn: '-1s' }
-    );
-
-    const res = await request(app)
-      .get('/api/auth/me')
-      .set('Authorization', `Bearer ${token}`);
-
-    expect(res.status).toBe(401);
-  });
-
-  test('401 — user not found in db', async () => {
+  it('returns 401 when user no longer exists', async () => {
     prisma.user.findUnique.mockResolvedValue(null);
 
     const res = await request(app)
       .get('/api/auth/me')
-      .set('Authorization', `Bearer ${makeToken()}`);
+      .set('Authorization', `Bearer ${validToken()}`);
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for expired token', async () => {
+    const expiredToken = jwt.sign({ sub: 'user-1' }, 'test-secret', { expiresIn: '0s' });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${expiredToken}`);
 
     expect(res.status).toBe(401);
   });

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Auth App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Auth App</title>
   </head>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,36 +1,35 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "private": true,
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "@emotion/react": "^11.11.4",
-    "@emotion/styled": "^11.11.5",
-    "@mui/icons-material": "^5.15.15",
-    "@mui/material": "^5.15.15",
-    "axios": "^1.6.8",
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.0",
+    "@mui/material": "^5.15.0",
+    "axios": "^1.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.21.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/react": "^15.0.2",
-    "@testing-library/user-event": "^14.5.2",
-    "@types/react": "^18.2.79",
-    "@types/react-dom": "^18.2.25",
-    "@vitejs/plugin-react": "^4.2.1",
-    "@vitest/coverage-v8": "^1.4.0",
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/user-event": "^14.5.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
     "jsdom": "^24.0.0",
-    "typescript": "^5.4.4",
-    "vite": "^5.2.8",
-    "vitest": "^1.4.0"
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.2.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
+    "@mui/icons-material": "^5.15.15",
+    "@mui/material": "^5.15.15",
+    "axios": "^1.6.8",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^15.0.2",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.2.79",
+    "@types/react-dom": "^18.2.25",
+    "@vitejs/plugin-react": "^4.2.1",
+    "@vitest/coverage-v8": "^1.4.0",
+    "jsdom": "^24.0.0",
+    "typescript": "^5.4.4",
+    "vite": "^5.2.8",
+    "vitest": "^1.4.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,11 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { ThemeProvider, CssBaseline } from '@mui/material';
-import { createTheme } from '@mui/material/styles';
-import LoginPage from './pages/LoginPage';
-import RegisterPage from './pages/RegisterPage';
-import DashboardPage from './pages/DashboardPage';
-import ProtectedRoute from './components/ProtectedRoute';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material'
+import LoginPage from './pages/LoginPage'
+import RegisterPage from './pages/RegisterPage'
+import DashboardPage from './pages/DashboardPage'
+import ProtectedRoute from './components/ProtectedRoute'
 
-const theme = createTheme();
+const theme = createTheme()
 
 export default function App() {
   return (
@@ -28,5 +27,5 @@ export default function App() {
         </Routes>
       </BrowserRouter>
     </ThemeProvider>
-  );
+  )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
+
+const theme = createTheme();
+
+export default function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/" element={<Navigate to="/login" replace />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
+  );
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { createTheme } from '@mui/material/styles';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
+import DashboardPage from './pages/DashboardPage';
+import ProtectedRoute from './components/ProtectedRoute';
 
 const theme = createTheme();
 
@@ -14,7 +16,15 @@ export default function App() {
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
-          <Route path="/" element={<Navigate to="/login" replace />} />
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <DashboardPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="*" element={<Navigate to="/login" replace />} />
         </Routes>
       </BrowserRouter>
     </ThemeProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { ThemeProvider, createTheme, CssBaseline } from '@mui/material'
+import { ThemeProvider, CssBaseline } from '@mui/material'
+import { createTheme } from '@mui/material/styles'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
 import DashboardPage from './pages/DashboardPage'

--- a/frontend/src/api/__tests__/authApi.test.ts
+++ b/frontend/src/api/__tests__/authApi.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import { login, register, getMe } from '../authApi';
+
+vi.mock('axios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('axios')>();
+  return {
+    default: {
+      ...actual.default,
+      create: vi.fn(() => ({
+        post: vi.fn(),
+        get: vi.fn(),
+        interceptors: {
+          request: { use: vi.fn() },
+          response: { use: vi.fn() },
+        },
+      })),
+    },
+  };
+});
+
+import * as authApiModule from '../authApi';
+
+describe('authApi', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('login resolves with token data', async () => {
+    const mockResponse = { token: 'abc', user: { id: '1', email: 'a@b.com', createdAt: '' } };
+    vi.spyOn(authApiModule, 'login').mockResolvedValueOnce(mockResponse);
+    const result = await authApiModule.login({ email: 'a@b.com', password: 'pass' });
+    expect(result.token).toBe('abc');
+  });
+
+  it('login throws on error', async () => {
+    vi.spyOn(authApiModule, 'login').mockRejectedValueOnce(new Error('Invalid credentials'));
+    await expect(authApiModule.login({ email: 'a@b.com', password: 'wrong' })).rejects.toThrow('Invalid credentials');
+  });
+
+  it('register resolves with token data', async () => {
+    const mockResponse = { token: 'xyz', user: { id: '2', email: 'c@d.com', createdAt: '' } };
+    vi.spyOn(authApiModule, 'register').mockResolvedValueOnce(mockResponse);
+    const result = await authApiModule.register({ email: 'c@d.com', password: 'pass1234' });
+    expect(result.token).toBe('xyz');
+  });
+
+  it('register throws on duplicate email', async () => {
+    vi.spyOn(authApiModule, 'register').mockRejectedValueOnce(new Error('Email already in use'));
+    await expect(authApiModule.register({ email: 'dup@email.com', password: 'pass' })).rejects.toThrow('Email already in use');
+  });
+
+  it('getMe resolves with user data', async () => {
+    const mockUser = { id: '1', email: 'a@b.com', createdAt: '' };
+    vi.spyOn(authApiModule, 'getMe').mockResolvedValueOnce(mockUser);
+    const result = await authApiModule.getMe();
+    expect(result.email).toBe('a@b.com');
+  });
+
+  it('getMe throws on unauthorized', async () => {
+    vi.spyOn(authApiModule, 'getMe').mockRejectedValueOnce(new Error('Unauthorized'));
+    await expect(authApiModule.getMe()).rejects.toThrow('Unauthorized');
+  });
+});

--- a/frontend/src/api/auth.test.ts
+++ b/frontend/src/api/auth.test.ts
@@ -1,0 +1,41 @@
+import { loginApi, registerApi } from './auth';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const okResp = (body: unknown) =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response);
+
+const errResp = (status: number, body: unknown) =>
+  Promise.resolve({ ok: false, status, json: () => Promise.resolve(body) } as Response);
+
+beforeEach(() => mockFetch.mockReset());
+
+test('loginApi sends POST and returns auth response', async () => {
+  mockFetch.mockReturnValueOnce(okResp({ token: 't', user: { id: '1', email: 'a@b.com', createdAt: '' } }));
+  const res = await loginApi({ email: 'a@b.com', password: 'pass' });
+  expect(res.token).toBe('t');
+  expect(mockFetch).toHaveBeenCalledWith('/api/auth/login', expect.objectContaining({ method: 'POST' }));
+});
+
+test('loginApi throws with server message on error', async () => {
+  mockFetch.mockReturnValueOnce(errResp(401, { message: 'Invalid credentials' }));
+  await expect(loginApi({ email: 'x@y.com', password: 'bad' })).rejects.toThrow('Invalid credentials');
+});
+
+test('registerApi sends POST and returns auth response', async () => {
+  mockFetch.mockReturnValueOnce(okResp({ token: 'r', user: { id: '2', email: 'b@c.com', createdAt: '' } }));
+  const res = await registerApi({ email: 'b@c.com', password: 'pass123' });
+  expect(res.token).toBe('r');
+  expect(mockFetch).toHaveBeenCalledWith('/api/auth/register', expect.objectContaining({ method: 'POST' }));
+});
+
+test('registerApi throws on 409', async () => {
+  mockFetch.mockReturnValueOnce(errResp(409, { message: 'Email already taken' }));
+  await expect(registerApi({ email: 'dup@b.com', password: 'pass123' })).rejects.toThrow('Email already taken');
+});
+
+test('loginApi throws generic message when no message in body', async () => {
+  mockFetch.mockReturnValueOnce(errResp(500, {}));
+  await expect(loginApi({ email: 'a@b.com', password: 'p' })).rejects.toThrow('HTTP 500');
+});

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,32 @@
+import { LoginRequest, RegisterRequest, AuthResponse } from '../types/auth';
+
+const BASE = '/api/auth';
+
+async function handleResponse<T>(res: Response): Promise<T> {
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = (data as { message?: string }).message || `HTTP ${res.status}`;
+    const err = new Error(msg) as Error & { status: number };
+    err.status = res.status;
+    throw err;
+  }
+  return data as T;
+}
+
+export async function loginApi(payload: LoginRequest): Promise<AuthResponse> {
+  const res = await fetch(`${BASE}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse<AuthResponse>(res);
+}
+
+export async function registerApi(payload: Omit<RegisterRequest, 'confirmPassword'>): Promise<AuthResponse> {
+  const res = await fetch(`${BASE}/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return handleResponse<AuthResponse>(res);
+}

--- a/frontend/src/api/authApi.test.ts
+++ b/frontend/src/api/authApi.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+
+vi.mock('axios', () => {
+  const mockAxios: any = {
+    create: vi.fn(),
+  }
+  return { default: mockAxios }
+})
+
+describe('getApiErrorMessage', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('extracts message from AxiosError response', async () => {
+    const { getApiErrorMessage } = await import('./authApi')
+    const { AxiosError } = await import('axios')
+    const err = new AxiosError('fail')
+    err.response = { data: { message: 'Invalid credentials' }, status: 401 } as any
+    expect(getApiErrorMessage(err)).toBe('Invalid credentials')
+  })
+
+  it('uses error message when no response data', async () => {
+    const { getApiErrorMessage } = await import('./authApi')
+    const { AxiosError } = await import('axios')
+    const err = new AxiosError('Network Error')
+    expect(getApiErrorMessage(err)).toBe('Network Error')
+  })
+
+  it('returns generic message for unknown errors', async () => {
+    const { getApiErrorMessage } = await import('./authApi')
+    expect(getApiErrorMessage(new Error('something'))).toBe('An unexpected error occurred')
+  })
+})

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -1,0 +1,49 @@
+import axios, { AxiosError } from 'axios';
+import type { LoginCredentials, RegisterCredentials, AuthResponse, AuthUser } from '../types/auth';
+
+const api = axios.create({
+  baseURL: '/api',
+  headers: { 'Content-Type': 'application/json' },
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+function extractMessage(error: unknown): string {
+  if (error instanceof AxiosError) {
+    return error.response?.data?.message ?? error.message;
+  }
+  return 'An unexpected error occurred';
+}
+
+export async function login(credentials: LoginCredentials): Promise<AuthResponse> {
+  try {
+    const { data } = await api.post<AuthResponse>('/auth/login', credentials);
+    return data;
+  } catch (error) {
+    throw new Error(extractMessage(error));
+  }
+}
+
+export async function register(credentials: Omit<RegisterCredentials, 'confirmPassword'>): Promise<AuthResponse> {
+  try {
+    const { data } = await api.post<AuthResponse>('/auth/register', credentials);
+    return data;
+  } catch (error) {
+    throw new Error(extractMessage(error));
+  }
+}
+
+export async function getMe(): Promise<AuthUser> {
+  try {
+    const { data } = await api.get<AuthUser>('/auth/me');
+    return data;
+  } catch (error) {
+    throw new Error(extractMessage(error));
+  }
+}

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -8,30 +8,28 @@ const api = axios.create({
 
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('token')
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`
-  }
+  if (token) config.headers.Authorization = `Bearer ${token}`
   return config
 })
 
-export async function login(data: LoginRequest): Promise<AuthResponse> {
-  const response = await api.post<AuthResponse>('/auth/login', data)
-  return response.data
+export async function loginApi(data: LoginRequest): Promise<AuthResponse> {
+  const res = await api.post<AuthResponse>('/auth/login', data)
+  return res.data
 }
 
-export async function register(data: Omit<RegisterRequest, 'confirmPassword'>): Promise<AuthResponse> {
-  const response = await api.post<AuthResponse>('/auth/register', data)
-  return response.data
+export async function registerApi(data: Omit<RegisterRequest, 'confirmPassword'>): Promise<AuthResponse> {
+  const res = await api.post<AuthResponse>('/auth/register', data)
+  return res.data
 }
 
-export async function getMe(): Promise<User> {
-  const response = await api.get<User>('/auth/me')
-  return response.data
+export async function getMeApi(): Promise<User> {
+  const res = await api.get<User>('/auth/me')
+  return res.data
 }
 
-export function getApiErrorMessage(error: unknown): string {
+export function getApiErrorMessage(error: unknown, fallback = 'An unexpected error occurred'): string {
   if (error instanceof AxiosError) {
-    return error.response?.data?.message ?? error.message
+    return error.response?.data?.message ?? fallback
   }
-  return 'An unexpected error occurred'
+  return fallback
 }

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -1,49 +1,37 @@
-import axios, { AxiosError } from 'axios';
-import type { LoginCredentials, RegisterCredentials, AuthResponse, AuthUser } from '../types/auth';
+import axios, { AxiosError } from 'axios'
+import type { LoginRequest, RegisterRequest, AuthResponse, User } from '../types/auth'
 
 const api = axios.create({
   baseURL: '/api',
   headers: { 'Content-Type': 'application/json' },
-});
+})
 
 api.interceptors.request.use((config) => {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem('token')
   if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+    config.headers.Authorization = `Bearer ${token}`
   }
-  return config;
-});
+  return config
+})
 
-function extractMessage(error: unknown): string {
+export async function login(data: LoginRequest): Promise<AuthResponse> {
+  const response = await api.post<AuthResponse>('/auth/login', data)
+  return response.data
+}
+
+export async function register(data: Omit<RegisterRequest, 'confirmPassword'>): Promise<AuthResponse> {
+  const response = await api.post<AuthResponse>('/auth/register', data)
+  return response.data
+}
+
+export async function getMe(): Promise<User> {
+  const response = await api.get<User>('/auth/me')
+  return response.data
+}
+
+export function getApiErrorMessage(error: unknown): string {
   if (error instanceof AxiosError) {
-    return error.response?.data?.message ?? error.message;
+    return error.response?.data?.message ?? error.message
   }
-  return 'An unexpected error occurred';
-}
-
-export async function login(credentials: LoginCredentials): Promise<AuthResponse> {
-  try {
-    const { data } = await api.post<AuthResponse>('/auth/login', credentials);
-    return data;
-  } catch (error) {
-    throw new Error(extractMessage(error));
-  }
-}
-
-export async function register(credentials: Omit<RegisterCredentials, 'confirmPassword'>): Promise<AuthResponse> {
-  try {
-    const { data } = await api.post<AuthResponse>('/auth/register', credentials);
-    return data;
-  } catch (error) {
-    throw new Error(extractMessage(error));
-  }
-}
-
-export async function getMe(): Promise<AuthUser> {
-  try {
-    const { data } = await api.get<AuthUser>('/auth/me');
-    return data;
-  } catch (error) {
-    throw new Error(extractMessage(error));
-  }
+  return 'An unexpected error occurred'
 }

--- a/frontend/src/components/AuthLayout.tsx
+++ b/frontend/src/components/AuthLayout.tsx
@@ -1,0 +1,45 @@
+import { Box, Card, CardContent, Typography } from '@mui/material';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+
+interface Props {
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function AuthLayout({ title, children }: Props) {
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        bgcolor: 'grey.100',
+        p: 2,
+      }}
+    >
+      <Card sx={{ maxWidth: 420, width: '100%' }} elevation={3}>
+        <CardContent sx={{ p: 4 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 3 }}>
+            <Box
+              sx={{
+                bgcolor: 'primary.main',
+                borderRadius: '50%',
+                p: 1,
+                mb: 1,
+                color: 'white',
+                display: 'flex',
+              }}
+            >
+              <LockOutlinedIcon />
+            </Box>
+            <Typography component="h1" variant="h5" fontWeight={600}>
+              {title}
+            </Typography>
+          </Box>
+          {children}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,53 +1,38 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
-import { vi } from 'vitest'
 import ProtectedRoute from './ProtectedRoute'
-import * as useAuthModule from '../hooks/useAuth'
+
+const renderWithRouter = (token: string | null) => {
+  if (token) localStorage.setItem('token', token)
+  else localStorage.removeItem('token')
+
+  return render(
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Routes>
+        <Route path="/login" element={<div>Login Page</div>} />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <div>Dashboard Content</div>
+            </ProtectedRoute>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
 
 describe('ProtectedRoute', () => {
-  afterEach(() => {
-    vi.restoreAllMocks()
-    localStorage.clear()
-  })
+  afterEach(() => localStorage.clear())
 
   it('renders children when authenticated', () => {
-    localStorage.setItem('token', 'valid-token')
-    render(
-      <MemoryRouter initialEntries={['/dashboard']}>
-        <Routes>
-          <Route
-            path="/dashboard"
-            element={
-              <ProtectedRoute>
-                <div>Dashboard Content</div>
-              </ProtectedRoute>
-            }
-          />
-          <Route path="/login" element={<div>Login Page</div>} />
-        </Routes>
-      </MemoryRouter>
-    )
-    expect(screen.getByText('Dashboard Content')).toBeInTheDocument()
+    renderWithRouter('valid-token')
+    expect(screen.getByText('Dashboard Content')).toBeDefined()
   })
 
   it('redirects to /login when not authenticated', () => {
-    localStorage.removeItem('token')
-    render(
-      <MemoryRouter initialEntries={['/dashboard']}>
-        <Routes>
-          <Route
-            path="/dashboard"
-            element={
-              <ProtectedRoute>
-                <div>Dashboard Content</div>
-              </ProtectedRoute>
-            }
-          />
-          <Route path="/login" element={<div>Login Page</div>} />
-        </Routes>
-      </MemoryRouter>
-    )
-    expect(screen.getByText('Login Page')).toBeInTheDocument()
-    expect(screen.queryByText('Dashboard Content')).not.toBeInTheDocument()
+    renderWithRouter(null)
+    expect(screen.getByText('Login Page')).toBeDefined()
   })
 })

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { vi } from 'vitest'
+import ProtectedRoute from './ProtectedRoute'
+import * as useAuthModule from '../hooks/useAuth'
+
+describe('ProtectedRoute', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('renders children when authenticated', () => {
+    localStorage.setItem('token', 'valid-token')
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <div>Dashboard Content</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>Login Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+    expect(screen.getByText('Dashboard Content')).toBeInTheDocument()
+  })
+
+  it('redirects to /login when not authenticated', () => {
+    localStorage.removeItem('token')
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <div>Dashboard Content</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>Login Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    )
+    expect(screen.getByText('Login Page')).toBeInTheDocument()
+    expect(screen.queryByText('Dashboard Content')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,13 @@
+import { Navigate } from 'react-router-dom';
+import { isAuthenticated } from '../hooks/useAuth';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function ProtectedRoute({ children }: Props) {
+  if (!isAuthenticated()) {
+    return <Navigate to="/login" replace />;
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,13 +1,13 @@
-import { Navigate } from 'react-router-dom';
-import { isAuthenticated } from '../hooks/useAuth';
+import { Navigate } from 'react-router-dom'
+import { isAuthenticated } from '../hooks/useAuth'
 
 interface Props {
-  children: React.ReactNode;
+  children: React.ReactNode
 }
 
 export default function ProtectedRoute({ children }: Props) {
   if (!isAuthenticated()) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to="/login" replace />
   }
-  return <>{children}</>;
+  return <>{children}</>
 }

--- a/frontend/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, it, expect, beforeEach } from 'vitest';
+import ProtectedRoute from '../ProtectedRoute';
+
+function renderWithRoutes(token: string | null) {
+  if (token) {
+    localStorage.setItem('token', token);
+  } else {
+    localStorage.removeItem('token');
+  }
+  return render(
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Routes>
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <div>Protected Content</div>
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/login" element={<div>Login Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('renders children when token is present', () => {
+    renderWithRoutes('valid-token');
+    expect(screen.getByText('Protected Content')).toBeInTheDocument();
+  });
+
+  it('redirects to /login when no token', () => {
+    renderWithRoutes(null);
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/useAuth.test.ts
+++ b/frontend/src/hooks/useAuth.test.ts
@@ -1,0 +1,34 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAuth } from './useAuth';
+
+beforeEach(() => localStorage.clear());
+
+test('setToken stores token', () => {
+  const { result } = renderHook(() => useAuth());
+  act(() => result.current.setToken('abc'));
+  expect(localStorage.getItem('auth_token')).toBe('abc');
+});
+
+test('getToken returns stored token', () => {
+  localStorage.setItem('auth_token', 'xyz');
+  const { result } = renderHook(() => useAuth());
+  expect(result.current.getToken()).toBe('xyz');
+});
+
+test('clearToken removes token', () => {
+  localStorage.setItem('auth_token', 'xyz');
+  const { result } = renderHook(() => useAuth());
+  act(() => result.current.clearToken());
+  expect(localStorage.getItem('auth_token')).toBeNull();
+});
+
+test('isAuthenticated returns true when token present', () => {
+  localStorage.setItem('auth_token', 'tok');
+  const { result } = renderHook(() => useAuth());
+  expect(result.current.isAuthenticated()).toBe(true);
+});
+
+test('isAuthenticated returns false when no token', () => {
+  const { result } = renderHook(() => useAuth());
+  expect(result.current.isAuthenticated()).toBe(false);
+});

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,52 +1,52 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { login as apiLogin, register as apiRegister } from '../api/authApi';
-import type { LoginCredentials, RegisterCredentials } from '../types/auth';
+import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { login as apiLogin, register as apiRegister, getApiErrorMessage } from '../api/authApi'
+import type { LoginRequest, RegisterRequest } from '../types/auth'
 
 export function useLogin() {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
 
-  async function handleLogin(credentials: LoginCredentials) {
-    setLoading(true);
-    setError(null);
+  const submit = useCallback(async (data: LoginRequest) => {
+    setLoading(true)
+    setError(null)
     try {
-      const { token } = await apiLogin(credentials);
-      localStorage.setItem('token', token);
-      navigate('/dashboard', { replace: true });
+      const response = await apiLogin(data)
+      localStorage.setItem('token', response.token)
+      navigate('/dashboard', { replace: true })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Login failed');
+      setError(getApiErrorMessage(err))
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  }
+  }, [navigate])
 
-  return { handleLogin, loading, error };
+  return { submit, loading, error }
 }
 
 export function useRegister() {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
 
-  async function handleRegister(credentials: Omit<RegisterCredentials, 'confirmPassword'>) {
-    setLoading(true);
-    setError(null);
+  const submit = useCallback(async (data: Omit<RegisterRequest, 'confirmPassword'>) => {
+    setLoading(true)
+    setError(null)
     try {
-      const { token } = await apiRegister(credentials);
-      localStorage.setItem('token', token);
-      navigate('/dashboard', { replace: true });
+      const response = await apiRegister(data)
+      localStorage.setItem('token', response.token)
+      navigate('/dashboard', { replace: true })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Registration failed');
+      setError(getApiErrorMessage(err))
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  }
+  }, [navigate])
 
-  return { handleRegister, loading, error };
+  return { submit, loading, error }
 }
 
 export function isAuthenticated(): boolean {
-  return Boolean(localStorage.getItem('token'));
+  return !!localStorage.getItem('token')
 }

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,19 @@
+import { useCallback } from 'react';
+
+const TOKEN_KEY = 'auth_token';
+
+export function useAuth() {
+  const getToken = useCallback(() => localStorage.getItem(TOKEN_KEY), []);
+
+  const setToken = useCallback((token: string) => {
+    localStorage.setItem(TOKEN_KEY, token);
+  }, []);
+
+  const clearToken = useCallback(() => {
+    localStorage.removeItem(TOKEN_KEY);
+  }, []);
+
+  const isAuthenticated = useCallback(() => !!localStorage.getItem(TOKEN_KEY), []);
+
+  return { getToken, setToken, clearToken, isAuthenticated };
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { login as apiLogin, register as apiRegister, getApiErrorMessage } from '../api/authApi'
+import { loginApi, registerApi, getApiErrorMessage } from '../api/authApi'
 import type { LoginRequest, RegisterRequest } from '../types/auth'
 
 export function useLogin() {
@@ -8,21 +8,21 @@ export function useLogin() {
   const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
 
-  const submit = useCallback(async (data: LoginRequest) => {
+  const login = useCallback(async (data: LoginRequest) => {
     setLoading(true)
     setError(null)
     try {
-      const response = await apiLogin(data)
-      localStorage.setItem('token', response.token)
+      const res = await loginApi(data)
+      localStorage.setItem('token', res.token)
       navigate('/dashboard', { replace: true })
     } catch (err) {
-      setError(getApiErrorMessage(err))
+      setError(getApiErrorMessage(err, 'Invalid email or password'))
     } finally {
       setLoading(false)
     }
   }, [navigate])
 
-  return { submit, loading, error }
+  return { login, loading, error }
 }
 
 export function useRegister() {
@@ -30,21 +30,21 @@ export function useRegister() {
   const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
 
-  const submit = useCallback(async (data: Omit<RegisterRequest, 'confirmPassword'>) => {
+  const register = useCallback(async (data: Omit<RegisterRequest, 'confirmPassword'>) => {
     setLoading(true)
     setError(null)
     try {
-      const response = await apiRegister(data)
-      localStorage.setItem('token', response.token)
+      const res = await registerApi(data)
+      localStorage.setItem('token', res.token)
       navigate('/dashboard', { replace: true })
     } catch (err) {
-      setError(getApiErrorMessage(err))
+      setError(getApiErrorMessage(err, 'Registration failed'))
     } finally {
       setLoading(false)
     }
   }, [navigate])
 
-  return { submit, loading, error }
+  return { register, loading, error }
 }
 
 export function isAuthenticated(): boolean {

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,19 +1,52 @@
-import { useCallback } from 'react';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { login as apiLogin, register as apiRegister } from '../api/authApi';
+import type { LoginCredentials, RegisterCredentials } from '../types/auth';
 
-const TOKEN_KEY = 'auth_token';
+export function useLogin() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
 
-export function useAuth() {
-  const getToken = useCallback(() => localStorage.getItem(TOKEN_KEY), []);
+  async function handleLogin(credentials: LoginCredentials) {
+    setLoading(true);
+    setError(null);
+    try {
+      const { token } = await apiLogin(credentials);
+      localStorage.setItem('token', token);
+      navigate('/dashboard', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  }
 
-  const setToken = useCallback((token: string) => {
-    localStorage.setItem(TOKEN_KEY, token);
-  }, []);
+  return { handleLogin, loading, error };
+}
 
-  const clearToken = useCallback(() => {
-    localStorage.removeItem(TOKEN_KEY);
-  }, []);
+export function useRegister() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
 
-  const isAuthenticated = useCallback(() => !!localStorage.getItem(TOKEN_KEY), []);
+  async function handleRegister(credentials: Omit<RegisterCredentials, 'confirmPassword'>) {
+    setLoading(true);
+    setError(null);
+    try {
+      const { token } = await apiRegister(credentials);
+      localStorage.setItem('token', token);
+      navigate('/dashboard', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Registration failed');
+    } finally {
+      setLoading(false);
+    }
+  }
 
-  return { getToken, setToken, clearToken, isAuthenticated };
+  return { handleRegister, loading, error };
+}
+
+export function isAuthenticated(): boolean {
+  return Boolean(localStorage.getItem('token'));
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('Root element not found');
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,12 +1,9 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
 
-const root = document.getElementById('root');
-if (!root) throw new Error('Root element not found');
-
-createRoot(root).render(
-  <StrictMode>
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
     <App />
-  </StrictMode>
-);
+  </React.StrictMode>
+)

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,8 +1,21 @@
-import { Box, Button, Container, Typography } from '@mui/material'
+import { useEffect, useState } from 'react'
+import { Box, Button, Container, Typography, CircularProgress, Alert } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
+import { getMeApi, getApiErrorMessage } from '../api/authApi'
+import type { User } from '../types/auth'
 
 export default function DashboardPage() {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
+
+  useEffect(() => {
+    getMeApi()
+      .then(setUser)
+      .catch((err) => setError(getApiErrorMessage(err, 'Failed to load user')))
+      .finally(() => setLoading(false))
+  }, [])
 
   const handleLogout = () => {
     localStorage.removeItem('token')
@@ -10,29 +23,32 @@ export default function DashboardPage() {
   }
 
   return (
-    <Container maxWidth="md">
-      <Box
-        sx={{
-          minHeight: '100vh',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: 3,
-        }}
-      >
-        <Typography component="h1" variant="h4" fontWeight={700}>
+    <Container maxWidth="sm">
+      <Box sx={{ mt: 8, textAlign: 'center' }}>
+        <Typography variant="h4" component="h1" gutterBottom>
           Dashboard
         </Typography>
-        <Typography variant="body1" color="text.secondary">
-          You are successfully logged in.
-        </Typography>
+
+        {loading && <CircularProgress aria-label="Loading user data" />}
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} role="alert">
+            {error}
+          </Alert>
+        )}
+
+        {user && (
+          <Typography variant="body1" sx={{ mb: 3 }}>
+            Welcome, <strong>{user.email}</strong>
+          </Typography>
+        )}
+
         <Button
           variant="outlined"
           onClick={handleLogout}
-          aria-label="Logout"
+          aria-label="Log out"
         >
-          Logout
+          Log Out
         </Button>
       </Box>
     </Container>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Box, Typography, Button, CircularProgress, Alert } from '@mui/material';
+import { getMe } from '../api/authApi';
+import type { AuthUser } from '../types/auth';
+
+export default function DashboardPage() {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getMe()
+      .then(setUser)
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function handleLogout() {
+    localStorage.removeItem('token');
+    navigate('/login', { replace: true });
+  }
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        p: 4,
+      }}
+    >
+      {loading && <CircularProgress aria-label="Loading user data" />}
+      {error && <Alert severity="error">{error}</Alert>}
+      {user && (
+        <>
+          <Typography variant="h4" component="h1">
+            Welcome, {user.email}!
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            You are logged in.
+          </Typography>
+        </>
+      )}
+      <Button variant="outlined" onClick={handleLogout} aria-label="Logout">
+        Logout
+      </Button>
+    </Box>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,54 +1,40 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Box, Typography, Button, CircularProgress, Alert } from '@mui/material';
-import { getMe } from '../api/authApi';
-import type { AuthUser } from '../types/auth';
+import { Box, Button, Container, Typography } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
 
 export default function DashboardPage() {
-  const [user, setUser] = useState<AuthUser | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const navigate = useNavigate();
+  const navigate = useNavigate()
 
-  useEffect(() => {
-    getMe()
-      .then(setUser)
-      .catch((err: Error) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, []);
-
-  function handleLogout() {
-    localStorage.removeItem('token');
-    navigate('/login', { replace: true });
+  const handleLogout = () => {
+    localStorage.removeItem('token')
+    navigate('/login', { replace: true })
   }
 
   return (
-    <Box
-      sx={{
-        minHeight: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: 2,
-        p: 4,
-      }}
-    >
-      {loading && <CircularProgress aria-label="Loading user data" />}
-      {error && <Alert severity="error">{error}</Alert>}
-      {user && (
-        <>
-          <Typography variant="h4" component="h1">
-            Welcome, {user.email}!
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            You are logged in.
-          </Typography>
-        </>
-      )}
-      <Button variant="outlined" onClick={handleLogout} aria-label="Logout">
-        Logout
-      </Button>
-    </Box>
-  );
+    <Container maxWidth="md">
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 3,
+        }}
+      >
+        <Typography component="h1" variant="h4" fontWeight={700}>
+          Dashboard
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          You are successfully logged in.
+        </Typography>
+        <Button
+          variant="outlined"
+          onClick={handleLogout}
+          aria-label="Logout"
+        >
+          Logout
+        </Button>
+      </Box>
+    </Container>
+  )
 }

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import LoginPage from './LoginPage';
+import * as authApi from '../api/auth';
+
+jest.mock('../api/auth');
+const mockLogin = authApi.loginApi as jest.MockedFunction<typeof authApi.loginApi>;
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockSetToken = jest.fn();
+jest.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ setToken: mockSetToken, getToken: jest.fn(), clearToken: jest.fn(), isAuthenticated: jest.fn() }),
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/login']}>
+      <LoginPage />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('renders email and password fields', () => {
+  renderPage();
+  expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+});
+
+test('renders sign in button', () => {
+  renderPage();
+  expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+});
+
+test('renders link to register page', () => {
+  renderPage();
+  expect(screen.getByRole('link', { name: /register/i })).toBeInTheDocument();
+});
+
+test('shows error on invalid credentials', async () => {
+  mockLogin.mockRejectedValueOnce(Object.assign(new Error('Invalid credentials'), { status: 401 }));
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
+  await userEvent.type(screen.getByLabelText(/^password$/i), 'wrongpass');
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+  await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Invalid credentials'));
+});
+
+test('stores token and redirects on success', async () => {
+  mockLogin.mockResolvedValueOnce({ token: 'tok123', user: { id: '1', email: 'a@b.com', createdAt: '' } });
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
+  await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+  await waitFor(() => {
+    expect(mockSetToken).toHaveBeenCalledWith('tok123');
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+  });
+});
+
+test('disables button while loading', async () => {
+  let resolve: (v: any) => void;
+  mockLogin.mockReturnValueOnce(new Promise((r) => { resolve = r; }));
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
+  await userEvent.type(screen.getByLabelText(/^password$/i), 'pass');
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+  await waitFor(() => expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled());
+});

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,78 +1,114 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import LoginPage from './LoginPage';
-import * as authApi from '../api/auth';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+import LoginPage from './LoginPage'
+import * as authApi from '../api/authApi'
 
-jest.mock('../api/auth');
-const mockLogin = authApi.loginApi as jest.MockedFunction<typeof authApi.loginApi>;
+vi.mock('../api/authApi')
 
-const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
-}));
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
 
-const mockSetToken = jest.fn();
-jest.mock('../hooks/useAuth', () => ({
-  useAuth: () => ({ setToken: mockSetToken, getToken: jest.fn(), clearToken: jest.fn(), isAuthenticated: jest.fn() }),
-}));
-
-const renderPage = () =>
-  render(
-    <MemoryRouter initialEntries={['/login']}>
+function renderLogin() {
+  return render(
+    <MemoryRouter>
       <LoginPage />
     </MemoryRouter>
-  );
+  )
+}
 
 beforeEach(() => {
-  jest.clearAllMocks();
-});
+  vi.clearAllMocks()
+  localStorage.clear()
+})
 
-test('renders email and password fields', () => {
-  renderPage();
-  expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
-  expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
-});
+describe('LoginPage', () => {
+  it('renders email and password fields', () => {
+    renderLogin()
+    expect(screen.getByLabelText('Email Address')).toBeInTheDocument()
+    expect(screen.getByLabelText('Password')).toBeInTheDocument()
+  })
 
-test('renders sign in button', () => {
-  renderPage();
-  expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
-});
+  it('renders sign in button', () => {
+    renderLogin()
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+  })
 
-test('renders link to register page', () => {
-  renderPage();
-  expect(screen.getByRole('link', { name: /register/i })).toBeInTheDocument();
-});
+  it('renders link to register', () => {
+    renderLogin()
+    expect(screen.getByRole('link', { name: /register/i })).toBeInTheDocument()
+  })
 
-test('shows error on invalid credentials', async () => {
-  mockLogin.mockRejectedValueOnce(Object.assign(new Error('Invalid credentials'), { status: 401 }));
-  renderPage();
-  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
-  await userEvent.type(screen.getByLabelText(/^password$/i), 'wrongpass');
-  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
-  await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Invalid credentials'));
-});
+  it('stores token and navigates on successful login', async () => {
+    vi.mocked(authApi.login).mockResolvedValueOnce({
+      token: 'test-jwt-token',
+      user: { id: '1', email: 'test@example.com', createdAt: new Date().toISOString() },
+    })
 
-test('stores token and redirects on success', async () => {
-  mockLogin.mockResolvedValueOnce({ token: 'tok123', user: { id: '1', email: 'a@b.com', createdAt: '' } });
-  renderPage();
-  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
-  await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
-  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
-  await waitFor(() => {
-    expect(mockSetToken).toHaveBeenCalledWith('tok123');
-    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
-  });
-});
+    renderLogin()
 
-test('disables button while loading', async () => {
-  let resolve: (v: any) => void;
-  mockLogin.mockReturnValueOnce(new Promise((r) => { resolve = r; }));
-  renderPage();
-  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
-  await userEvent.type(screen.getByLabelText(/^password$/i), 'pass');
-  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
-  await waitFor(() => expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled());
-});
+    fireEvent.change(screen.getByLabelText('Email Address'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(localStorage.getItem('token')).toBe('test-jwt-token')
+    })
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true })
+  })
+
+  it('shows error message on invalid credentials', async () => {
+    const { AxiosError } = await import('axios')
+    const err = new AxiosError('Request failed')
+    err.response = { data: { message: 'Invalid credentials' }, status: 401 } as any
+    vi.mocked(authApi.login).mockRejectedValueOnce(err)
+
+    renderLogin()
+
+    fireEvent.change(screen.getByLabelText('Email Address'), {
+      target: { value: 'bad@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'wrongpass' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Invalid credentials')
+    })
+    expect(localStorage.getItem('token')).toBeNull()
+  })
+
+  it('disables button and shows loading spinner during submission', async () => {
+    let resolve!: (v: any) => void
+    vi.mocked(authApi.login).mockReturnValueOnce(
+      new Promise((r) => { resolve = r })
+    )
+
+    renderLogin()
+
+    fireEvent.change(screen.getByLabelText('Email Address'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Loading')).toBeInTheDocument()
+    })
+
+    resolve({ token: 'tok', user: { id: '1', email: 'test@example.com', createdAt: '' } })
+  })
+})

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,114 +1,103 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { vi } from 'vitest'
 import LoginPage from './LoginPage'
 import * as authApi from '../api/authApi'
 
 vi.mock('../api/authApi')
-
-const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  }
+  return { ...actual, useNavigate: () => vi.fn() }
 })
 
-function renderLogin() {
-  return render(
+const renderLogin = () =>
+  render(
     <MemoryRouter>
       <LoginPage />
     </MemoryRouter>
   )
-}
-
-beforeEach(() => {
-  vi.clearAllMocks()
-  localStorage.clear()
-})
 
 describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
   it('renders email and password fields', () => {
     renderLogin()
-    expect(screen.getByLabelText('Email Address')).toBeInTheDocument()
-    expect(screen.getByLabelText('Password')).toBeInTheDocument()
+    expect(screen.getByLabelText(/email address/i)).toBeDefined()
+    expect(screen.getByLabelText(/^password$/i)).toBeDefined()
   })
 
   it('renders sign in button', () => {
     renderLogin()
-    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeDefined()
   })
 
-  it('renders link to register', () => {
+  it('renders link to register page', () => {
     renderLogin()
-    expect(screen.getByRole('link', { name: /register/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /register/i })).toBeDefined()
   })
 
-  it('stores token and navigates on successful login', async () => {
-    vi.mocked(authApi.login).mockResolvedValueOnce({
-      token: 'test-jwt-token',
-      user: { id: '1', email: 'test@example.com', createdAt: new Date().toISOString() },
-    })
-
+  it('shows validation errors when submitting empty form', async () => {
     renderLogin()
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'test@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'password123' },
-    })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
-
     await waitFor(() => {
-      expect(localStorage.getItem('token')).toBe('test-jwt-token')
+      expect(screen.getByText(/email is required/i)).toBeDefined()
+      expect(screen.getByText(/password is required/i)).toBeDefined()
     })
-    expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true })
   })
 
-  it('shows error message on invalid credentials', async () => {
-    const { AxiosError } = await import('axios')
-    const err = new AxiosError('Request failed')
-    err.response = { data: { message: 'Invalid credentials' }, status: 401 } as any
-    vi.mocked(authApi.login).mockRejectedValueOnce(err)
-
+  it('shows invalid email error', async () => {
     renderLogin()
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'bad@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'wrongpass' },
-    })
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'notanemail' } })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
-
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Invalid credentials')
+      expect(screen.getByText(/enter a valid email/i)).toBeDefined()
     })
-    expect(localStorage.getItem('token')).toBeNull()
   })
 
-  it('disables button and shows loading spinner during submission', async () => {
-    let resolve!: (v: any) => void
-    vi.mocked(authApi.login).mockReturnValueOnce(
-      new Promise((r) => { resolve = r })
-    )
-
+  it('calls loginApi with correct credentials', async () => {
+    const mockLogin = vi.spyOn(authApi, 'loginApi').mockResolvedValue({
+      token: 'test-token',
+      user: { id: '1', email: 'test@example.com', createdAt: '' },
+    })
     renderLogin()
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'test@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'password123' },
-    })
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'test@example.com' } })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'password123' } })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
-
     await waitFor(() => {
-      expect(screen.getByLabelText('Loading')).toBeInTheDocument()
+      expect(mockLogin).toHaveBeenCalledWith({ email: 'test@example.com', password: 'password123' })
     })
+  })
 
-    resolve({ token: 'tok', user: { id: '1', email: 'test@example.com', createdAt: '' } })
+  it('stores token in localStorage on success', async () => {
+    vi.spyOn(authApi, 'loginApi').mockResolvedValue({
+      token: 'jwt-token-xyz',
+      user: { id: '1', email: 'test@example.com', createdAt: '' },
+    })
+    renderLogin()
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'test@example.com' } })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'password123' } })
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
+    await waitFor(() => {
+      expect(localStorage.getItem('token')).toBe('jwt-token-xyz')
+    })
+  })
+
+  it('shows error alert on invalid credentials', async () => {
+    const axiosError = Object.assign(new Error(), {
+      isAxiosError: true,
+      response: { data: { message: 'Invalid credentials' }, status: 401 },
+    })
+    vi.spyOn(authApi, 'loginApi').mockRejectedValue(axiosError)
+    vi.spyOn(authApi, 'getApiErrorMessage').mockReturnValue('Invalid email or password')
+    renderLogin()
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'wrong@example.com' } })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'wrongpass' } })
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeDefined()
+      expect(screen.getByText(/invalid email or password/i)).toBeDefined()
+    })
   })
 })

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,109 +1,100 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import {
-  Box,
-  Button,
-  Container,
   TextField,
-  Typography,
+  Button,
   Alert,
-  CircularProgress,
-  Link as MuiLink,
-  Paper,
+  Box,
+  Link,
+  InputAdornment,
+  IconButton,
 } from '@mui/material';
-import { Link, useNavigate } from 'react-router-dom';
-import { loginApi } from '../api/auth';
-import { useAuth } from '../hooks/useAuth';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import AuthLayout from '../components/AuthLayout';
+import { useLogin } from '../hooks/useAuth';
 
 export default function LoginPage() {
-  const navigate = useNavigate();
-  const { setToken } = useAuth();
-
+  const { handleLogin, loading, error } = useLogin();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  async function onSubmit(e: FormEvent) {
     e.preventDefault();
-    setError(null);
-    setLoading(true);
-    try {
-      const { token } = await loginApi({ email, password });
-      setToken(token);
-      navigate('/dashboard');
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Login failed';
-      setError(msg);
-    } finally {
-      setLoading(false);
-    }
-  };
+    await handleLogin({ email, password });
+  }
 
   return (
-    <Container maxWidth="xs">
-      <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
-          <Typography component="h1" variant="h5" align="center" gutterBottom>
-            Sign In
-          </Typography>
+    <AuthLayout title="Sign In">
+      <Box
+        component="form"
+        onSubmit={onSubmit}
+        noValidate
+        aria-label="Login form"
+        sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+      >
+        {error && (
+          <Alert severity="error" role="alert">
+            {error}
+          </Alert>
+        )}
 
-          {error && (
-            <Alert severity="error" role="alert" sx={{ mb: 2 }}>
-              {error}
-            </Alert>
-          )}
+        <TextField
+          id="email"
+          label="Email Address"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          fullWidth
+          autoComplete="email"
+          autoFocus
+          inputProps={{ 'aria-required': true }}
+        />
 
-          <Box
-            component="form"
-            onSubmit={handleSubmit}
-            noValidate
-            aria-label="Login form"
-          >
-            <TextField
-              id="email"
-              label="Email Address"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              fullWidth
-              margin="normal"
-              autoComplete="email"
-              autoFocus
-              inputProps={{ 'aria-label': 'Email address' }}
-            />
-            <TextField
-              id="password"
-              label="Password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              fullWidth
-              margin="normal"
-              autoComplete="current-password"
-              inputProps={{ 'aria-label': 'Password' }}
-            />
-            <Button
-              type="submit"
-              fullWidth
-              variant="contained"
-              disabled={loading}
-              sx={{ mt: 3, mb: 2 }}
-              aria-label={loading ? 'Signing in…' : 'Sign in'}
-            >
-              {loading ? <CircularProgress size={24} color="inherit" /> : 'Sign In'}
-            </Button>
-          </Box>
+        <TextField
+          id="password"
+          label="Password"
+          type={showPassword ? 'text' : 'password'}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          fullWidth
+          autoComplete="current-password"
+          inputProps={{ 'aria-required': true }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  onClick={() => setShowPassword((s) => !s)}
+                  edge="end"
+                >
+                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
 
-          <Typography variant="body2" align="center">
-            Don&apos;t have an account?{' '}
-            <MuiLink component={Link} to="/register" underline="hover">
-              Register
-            </MuiLink>
-          </Typography>
-        </Paper>
+        <Button
+          type="submit"
+          variant="contained"
+          fullWidth
+          disabled={loading}
+          aria-busy={loading}
+          sx={{ mt: 1 }}
+        >
+          {loading ? 'Signing in…' : 'Sign In'}
+        </Button>
+
+        <Box sx={{ textAlign: 'center', mt: 1 }}>
+          <Link component={RouterLink} to="/register" variant="body2">
+            Don't have an account? Register
+          </Link>
+        </Box>
       </Box>
-    </Container>
+    </AuthLayout>
   );
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,100 +1,106 @@
-import { useState, type FormEvent } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { useState, FormEvent } from 'react'
 import {
-  TextField,
-  Button,
-  Alert,
   Box,
-  Link,
-  InputAdornment,
-  IconButton,
-} from '@mui/material';
-import Visibility from '@mui/icons-material/Visibility';
-import VisibilityOff from '@mui/icons-material/VisibilityOff';
-import AuthLayout from '../components/AuthLayout';
-import { useLogin } from '../hooks/useAuth';
+  Button,
+  CircularProgress,
+  Container,
+  TextField,
+  Typography,
+  Alert,
+  Paper,
+  Link as MuiLink,
+} from '@mui/material'
+import { Link } from 'react-router-dom'
+import { useLogin } from '../hooks/useAuth'
 
 export default function LoginPage() {
-  const { handleLogin, loading, error } = useLogin();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const { submit, loading, error } = useLogin()
 
-  async function onSubmit(e: FormEvent) {
-    e.preventDefault();
-    await handleLogin({ email, password });
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    submit({ email, password })
   }
 
   return (
-    <AuthLayout title="Sign In">
+    <Container maxWidth="xs">
       <Box
-        component="form"
-        onSubmit={onSubmit}
-        noValidate
-        aria-label="Login form"
-        sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+        }}
       >
-        {error && (
-          <Alert severity="error" role="alert">
-            {error}
-          </Alert>
-        )}
+        <Paper elevation={3} sx={{ p: 4 }}>
+          <Typography
+            component="h1"
+            variant="h5"
+            align="center"
+            gutterBottom
+            fontWeight={700}
+          >
+            Sign In
+          </Typography>
 
-        <TextField
-          id="email"
-          label="Email Address"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-          fullWidth
-          autoComplete="email"
-          autoFocus
-          inputProps={{ 'aria-required': true }}
-        />
+          {error && (
+            <Alert severity="error" role="alert" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
 
-        <TextField
-          id="password"
-          label="Password"
-          type={showPassword ? 'text' : 'password'}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          fullWidth
-          autoComplete="current-password"
-          inputProps={{ 'aria-required': true }}
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <IconButton
-                  aria-label={showPassword ? 'Hide password' : 'Show password'}
-                  onClick={() => setShowPassword((s) => !s)}
-                  edge="end"
-                >
-                  {showPassword ? <VisibilityOff /> : <Visibility />}
-                </IconButton>
-              </InputAdornment>
-            ),
-          }}
-        />
+          <Box
+            component="form"
+            onSubmit={handleSubmit}
+            noValidate
+            aria-label="Login form"
+          >
+            <TextField
+              id="email"
+              label="Email Address"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              margin="normal"
+              fullWidth
+              required
+              autoComplete="email"
+              autoFocus
+              inputProps={{ 'aria-label': 'Email Address' }}
+            />
+            <TextField
+              id="password"
+              label="Password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              margin="normal"
+              fullWidth
+              required
+              autoComplete="current-password"
+              inputProps={{ 'aria-label': 'Password' }}
+            />
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              disabled={loading}
+              sx={{ mt: 2, mb: 2 }}
+              aria-label="Sign in"
+            >
+              {loading ? <CircularProgress size={24} aria-label="Loading" /> : 'Sign In'}
+            </Button>
+          </Box>
 
-        <Button
-          type="submit"
-          variant="contained"
-          fullWidth
-          disabled={loading}
-          aria-busy={loading}
-          sx={{ mt: 1 }}
-        >
-          {loading ? 'Signing in…' : 'Sign In'}
-        </Button>
-
-        <Box sx={{ textAlign: 'center', mt: 1 }}>
-          <Link component={RouterLink} to="/register" variant="body2">
-            Don't have an account? Register
-          </Link>
-        </Box>
+          <Typography variant="body2" align="center">
+            Don&apos;t have an account?{' '}
+            <MuiLink component={Link} to="/register" underline="hover">
+              Register
+            </MuiLink>
+          </Typography>
+        </Paper>
       </Box>
-    </AuthLayout>
-  );
+    </Container>
+  )
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,26 +1,37 @@
-import { useState, FormEvent } from 'react'
+import { useState, type FormEvent } from 'react'
 import {
   Box,
   Button,
   CircularProgress,
   Container,
+  Link,
+  Paper,
   TextField,
   Typography,
   Alert,
-  Paper,
-  Link as MuiLink,
 } from '@mui/material'
-import { Link } from 'react-router-dom'
+import { Link as RouterLink } from 'react-router-dom'
 import { useLogin } from '../hooks/useAuth'
 
 export default function LoginPage() {
+  const { login, loading, error } = useLogin()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const { submit, loading, error } = useLogin()
+  const [fieldErrors, setFieldErrors] = useState({ email: '', password: '' })
 
-  const handleSubmit = (e: FormEvent) => {
+  const validate = (): boolean => {
+    const errors = { email: '', password: '' }
+    if (!email) errors.email = 'Email is required'
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errors.email = 'Enter a valid email'
+    if (!password) errors.password = 'Password is required'
+    setFieldErrors(errors)
+    return !errors.email && !errors.password
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
-    submit({ email, password })
+    if (!validate()) return
+    await login({ email, password })
   }
 
   return (
@@ -31,21 +42,16 @@ export default function LoginPage() {
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'center',
+          alignItems: 'center',
         }}
       >
-        <Paper elevation={3} sx={{ p: 4 }}>
-          <Typography
-            component="h1"
-            variant="h5"
-            align="center"
-            gutterBottom
-            fontWeight={700}
-          >
+        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
+          <Typography variant="h5" component="h1" gutterBottom align="center" fontWeight={700}>
             Sign In
           </Typography>
 
           {error && (
-            <Alert severity="error" role="alert" sx={{ mb: 2 }}>
+            <Alert severity="error" sx={{ mb: 2 }} role="alert">
               {error}
             </Alert>
           )}
@@ -57,47 +63,49 @@ export default function LoginPage() {
             aria-label="Login form"
           >
             <TextField
-              id="email"
-              label="Email Address"
+              label="Email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              margin="normal"
+              error={!!fieldErrors.email}
+              helperText={fieldErrors.email}
               fullWidth
-              required
+              margin="normal"
               autoComplete="email"
-              autoFocus
-              inputProps={{ 'aria-label': 'Email Address' }}
+              inputProps={{ 'aria-label': 'Email address' }}
+              disabled={loading}
             />
             <TextField
-              id="password"
               label="Password"
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              margin="normal"
+              error={!!fieldErrors.password}
+              helperText={fieldErrors.password}
               fullWidth
-              required
+              margin="normal"
               autoComplete="current-password"
               inputProps={{ 'aria-label': 'Password' }}
+              disabled={loading}
             />
             <Button
               type="submit"
-              fullWidth
               variant="contained"
+              fullWidth
+              size="large"
               disabled={loading}
-              sx={{ mt: 2, mb: 2 }}
-              aria-label="Sign in"
+              sx={{ mt: 2, mb: 1 }}
+              aria-label={loading ? 'Signing in…' : 'Sign in'}
             >
-              {loading ? <CircularProgress size={24} aria-label="Loading" /> : 'Sign In'}
+              {loading ? <CircularProgress size={24} color="inherit" /> : 'Sign In'}
             </Button>
           </Box>
 
-          <Typography variant="body2" align="center">
+          <Typography variant="body2" align="center" sx={{ mt: 1 }}>
             Don&apos;t have an account?{' '}
-            <MuiLink component={Link} to="/register" underline="hover">
+            <Link component={RouterLink} to="/register" underline="hover">
               Register
-            </MuiLink>
+            </Link>
           </Typography>
         </Paper>
       </Box>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  Container,
+  TextField,
+  Typography,
+  Alert,
+  CircularProgress,
+  Link as MuiLink,
+  Paper,
+} from '@mui/material';
+import { Link, useNavigate } from 'react-router-dom';
+import { loginApi } from '../api/auth';
+import { useAuth } from '../hooks/useAuth';
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const { setToken } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const { token } = await loginApi({ email, password });
+      setToken(token);
+      navigate('/dashboard');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Login failed';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Container maxWidth="xs">
+      <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
+          <Typography component="h1" variant="h5" align="center" gutterBottom>
+            Sign In
+          </Typography>
+
+          {error && (
+            <Alert severity="error" role="alert" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          <Box
+            component="form"
+            onSubmit={handleSubmit}
+            noValidate
+            aria-label="Login form"
+          >
+            <TextField
+              id="email"
+              label="Email Address"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              fullWidth
+              margin="normal"
+              autoComplete="email"
+              autoFocus
+              inputProps={{ 'aria-label': 'Email address' }}
+            />
+            <TextField
+              id="password"
+              label="Password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              fullWidth
+              margin="normal"
+              autoComplete="current-password"
+              inputProps={{ 'aria-label': 'Password' }}
+            />
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              disabled={loading}
+              sx={{ mt: 3, mb: 2 }}
+              aria-label={loading ? 'Signing in…' : 'Sign in'}
+            >
+              {loading ? <CircularProgress size={24} color="inherit" /> : 'Sign In'}
+            </Button>
+          </Box>
+
+          <Typography variant="body2" align="center">
+            Don&apos;t have an account?{' '}
+            <MuiLink component={Link} to="/register" underline="hover">
+              Register
+            </MuiLink>
+          </Typography>
+        </Paper>
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/src/pages/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage.test.tsx
@@ -1,90 +1,157 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
-import RegisterPage from './RegisterPage';
-import * as authApi from '../api/auth';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+import RegisterPage from './RegisterPage'
+import * as authApi from '../api/authApi'
 
-jest.mock('../api/auth');
-const mockRegister = authApi.registerApi as jest.MockedFunction<typeof authApi.registerApi>;
+vi.mock('../api/authApi')
 
-const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
-}));
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
 
-const mockSetToken = jest.fn();
-jest.mock('../hooks/useAuth', () => ({
-  useAuth: () => ({ setToken: mockSetToken, getToken: jest.fn(), clearToken: jest.fn(), isAuthenticated: jest.fn() }),
-}));
-
-const renderPage = () =>
-  render(
-    <MemoryRouter initialEntries={['/register']}>
+function renderRegister() {
+  return render(
+    <MemoryRouter>
       <RegisterPage />
     </MemoryRouter>
-  );
+  )
+}
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+})
 
-test('renders all fields', () => {
-  renderPage();
-  expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
-  expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
-  expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
-});
+describe('RegisterPage', () => {
+  it('renders all form fields', () => {
+    renderRegister()
+    expect(screen.getByLabelText('Email Address')).toBeInTheDocument()
+    expect(screen.getByLabelText('Password')).toBeInTheDocument()
+    expect(screen.getByLabelText('Confirm Password')).toBeInTheDocument()
+  })
 
-test('shows error when passwords do not match on submit', async () => {
-  renderPage();
-  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
-  await userEvent.type(screen.getByLabelText(/^password$/i), 'password1');
-  await userEvent.type(screen.getByLabelText(/confirm password/i), 'password2');
-  fireEvent.click(screen.getByRole('button', { name: /create account/i }));
-  await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Passwords do not match'));
-  expect(mockRegister).not.toHaveBeenCalled();
-});
+  it('renders link to login', () => {
+    renderRegister()
+    expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument()
+  })
 
-test('shows error when password too short', async () => {
-  renderPage();
-  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
-  await userEvent.type(screen.getByLabelText(/^password$/i), 'short');
-  await userEvent.type(screen.getByLabelText(/confirm password/i), 'short');
-  fireEvent.click(screen.getByRole('button', { name: /create account/i }));
-  await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('at least 8 characters'));
-});
+  it('shows error when passwords do not match', async () => {
+    renderRegister()
 
-test('shows inline helper when confirm password differs', async () => {
-  renderPage();
-  await userEvent.type(screen.getByLabelText(/^password$/i), 'password1');
-  await userEvent.type(screen.getByLabelText(/confirm password/i), 'other');
-  expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
-});
+    fireEvent.change(screen.getByLabelText('Email Address'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'different' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
 
-test('registers successfully and redirects', async () => {
-  mockRegister.mockResolvedValueOnce({ token: 'tok456', user: { id: '2', email: 'a@b.com', createdAt: '' } });
-  renderPage();
-  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
-  await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
-  await userEvent.type(screen.getByLabelText(/confirm password/i), 'password123');
-  fireEvent.click(screen.getByRole('button', { name: /create account/i }));
-  await waitFor(() => {
-    expect(mockSetToken).toHaveBeenCalledWith('tok456');
-    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
-  });
-});
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Passwords do not match')
+    })
+    expect(authApi.register).not.toHaveBeenCalled()
+  })
 
-test('shows API error on duplicate email', async () => {
-  mockRegister.mockRejectedValueOnce(Object.assign(new Error('Email already taken'), { status: 409 }));
-  renderPage();
-  await userEvent.type(screen.getByLabelText(/email address/i), 'dup@b.com');
-  await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
-  await userEvent.type(screen.getByLabelText(/confirm password/i), 'password123');
-  fireEvent.click(screen.getByRole('button', { name: /create account/i }));
-  await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Email already taken'));
-});
+  it('shows error when password is too short', async () => {
+    renderRegister()
 
-test('renders link to login page', () => {
-  renderPage();
-  expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument();
-});
+    fireEvent.change(screen.getByLabelText('Email Address'), {
+      target: { value: 'test@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: '123' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: '123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('at least 6 characters')
+    })
+  })
+
+  it('submits and navigates on successful registration', async () => {
+    vi.mocked(authApi.register).mockResolvedValueOnce({
+      token: 'reg-token',
+      user: { id: '2', email: 'new@example.com', createdAt: new Date().toISOString() },
+    })
+
+    renderRegister()
+
+    fireEvent.change(screen.getByLabelText('Email Address'), {
+      target: { value: 'new@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'securepass' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'securepass' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(localStorage.getItem('token')).toBe('reg-token')
+    })
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true })
+  })
+
+  it('shows API error on registration failure', async () => {
+    const { AxiosError } = await import('axios')
+    const err = new AxiosError('Conflict')
+    err.response = { data: { message: 'Email already taken' }, status: 409 } as any
+    vi.mocked(authApi.register).mockRejectedValueOnce(err)
+
+    renderRegister()
+
+    fireEvent.change(screen.getByLabelText('Email Address'), {
+      target: { value: 'taken@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'password123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Email already taken')
+    })
+  })
+
+  it('disables button during submission', async () => {
+    let resolve!: (v: any) => void
+    vi.mocked(authApi.register).mockReturnValueOnce(
+      new Promise((r) => { resolve = r })
+    )
+
+    renderRegister()
+
+    fireEvent.change(screen.getByLabelText('Email Address'), {
+      target: { value: 'new@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    })
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'password123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Loading')).toBeInTheDocument()
+    })
+
+    resolve({ token: 'tok', user: { id: '1', email: 'new@example.com', createdAt: '' } })
+  })
+})

--- a/frontend/src/pages/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage.test.tsx
@@ -1,157 +1,117 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { vi } from 'vitest'
 import RegisterPage from './RegisterPage'
 import * as authApi from '../api/authApi'
 
 vi.mock('../api/authApi')
-
-const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  }
+  return { ...actual, useNavigate: () => vi.fn() }
 })
 
-function renderRegister() {
-  return render(
+const renderRegister = () =>
+  render(
     <MemoryRouter>
       <RegisterPage />
     </MemoryRouter>
   )
-}
-
-beforeEach(() => {
-  vi.clearAllMocks()
-  localStorage.clear()
-})
 
 describe('RegisterPage', () => {
-  it('renders all form fields', () => {
-    renderRegister()
-    expect(screen.getByLabelText('Email Address')).toBeInTheDocument()
-    expect(screen.getByLabelText('Password')).toBeInTheDocument()
-    expect(screen.getByLabelText('Confirm Password')).toBeInTheDocument()
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
   })
 
-  it('renders link to login', () => {
+  it('renders all form fields', () => {
     renderRegister()
-    expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/email address/i)).toBeDefined()
+    expect(screen.getByLabelText(/^password$/i)).toBeDefined()
+    expect(screen.getByLabelText(/confirm password/i)).toBeDefined()
+  })
+
+  it('renders register button', () => {
+    renderRegister()
+    expect(screen.getByRole('button', { name: /register/i })).toBeDefined()
+  })
+
+  it('renders link to sign in page', () => {
+    renderRegister()
+    expect(screen.getByRole('link', { name: /sign in/i })).toBeDefined()
+  })
+
+  it('shows validation errors when submitting empty form', async () => {
+    renderRegister()
+    fireEvent.click(screen.getByRole('button', { name: /register/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/email is required/i)).toBeDefined()
+      expect(screen.getByText(/password is required/i)).toBeDefined()
+      expect(screen.getByText(/please confirm your password/i)).toBeDefined()
+    })
   })
 
   it('shows error when passwords do not match', async () => {
     renderRegister()
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'test@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'password123' },
-    })
-    fireEvent.change(screen.getByLabelText('Confirm Password'), {
-      target: { value: 'different' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
-
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'user@example.com' } })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'password123' } })
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'different' } })
+    fireEvent.click(screen.getByRole('button', { name: /register/i }))
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Passwords do not match')
+      expect(screen.getByText(/passwords do not match/i)).toBeDefined()
     })
-    expect(authApi.register).not.toHaveBeenCalled()
   })
 
   it('shows error when password is too short', async () => {
     renderRegister()
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'test@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: '123' },
-    })
-    fireEvent.change(screen.getByLabelText('Confirm Password'), {
-      target: { value: '123' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
-
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'user@example.com' } })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'short' } })
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'short' } })
+    fireEvent.click(screen.getByRole('button', { name: /register/i }))
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('at least 6 characters')
+      expect(screen.getByText(/at least 8 characters/i)).toBeDefined()
     })
   })
 
-  it('submits and navigates on successful registration', async () => {
-    vi.mocked(authApi.register).mockResolvedValueOnce({
-      token: 'reg-token',
-      user: { id: '2', email: 'new@example.com', createdAt: new Date().toISOString() },
+  it('calls registerApi with correct data when form is valid', async () => {
+    const mockRegister = vi.spyOn(authApi, 'registerApi').mockResolvedValue({
+      token: 'new-token',
+      user: { id: '2', email: 'user@example.com', createdAt: '' },
     })
-
     renderRegister()
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'new@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'securepass' },
-    })
-    fireEvent.change(screen.getByLabelText('Confirm Password'), {
-      target: { value: 'securepass' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
-
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'user@example.com' } })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'password123' } })
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'password123' } })
+    fireEvent.click(screen.getByRole('button', { name: /register/i }))
     await waitFor(() => {
-      expect(localStorage.getItem('token')).toBe('reg-token')
-    })
-    expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true })
-  })
-
-  it('shows API error on registration failure', async () => {
-    const { AxiosError } = await import('axios')
-    const err = new AxiosError('Conflict')
-    err.response = { data: { message: 'Email already taken' }, status: 409 } as any
-    vi.mocked(authApi.register).mockRejectedValueOnce(err)
-
-    renderRegister()
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'taken@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'password123' },
-    })
-    fireEvent.change(screen.getByLabelText('Confirm Password'), {
-      target: { value: 'password123' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
-
-    await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Email already taken')
+      expect(mockRegister).toHaveBeenCalledWith({ email: 'user@example.com', password: 'password123' })
     })
   })
 
-  it('disables button during submission', async () => {
-    let resolve!: (v: any) => void
-    vi.mocked(authApi.register).mockReturnValueOnce(
-      new Promise((r) => { resolve = r })
-    )
-
+  it('stores token in localStorage on successful registration', async () => {
+    vi.spyOn(authApi, 'registerApi').mockResolvedValue({
+      token: 'reg-token-abc',
+      user: { id: '2', email: 'user@example.com', createdAt: '' },
+    })
     renderRegister()
-
-    fireEvent.change(screen.getByLabelText('Email Address'), {
-      target: { value: 'new@example.com' },
-    })
-    fireEvent.change(screen.getByLabelText('Password'), {
-      target: { value: 'password123' },
-    })
-    fireEvent.change(screen.getByLabelText('Confirm Password'), {
-      target: { value: 'password123' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: /create account/i }))
-
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'user@example.com' } })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'password123' } })
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'password123' } })
+    fireEvent.click(screen.getByRole('button', { name: /register/i }))
     await waitFor(() => {
-      expect(screen.getByLabelText('Loading')).toBeInTheDocument()
+      expect(localStorage.getItem('token')).toBe('reg-token-abc')
     })
+  })
 
-    resolve({ token: 'tok', user: { id: '1', email: 'new@example.com', createdAt: '' } })
+  it('shows error alert on duplicate email (409)', async () => {
+    vi.spyOn(authApi, 'registerApi').mockRejectedValue(new Error())
+    vi.spyOn(authApi, 'getApiErrorMessage').mockReturnValue('Email already in use')
+    renderRegister()
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'taken@example.com' } })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'password123' } })
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'password123' } })
+    fireEvent.click(screen.getByRole('button', { name: /register/i }))
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeDefined()
+      expect(screen.getByText(/email already in use/i)).toBeDefined()
+    })
   })
 })

--- a/frontend/src/pages/RegisterPage.test.tsx
+++ b/frontend/src/pages/RegisterPage.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import RegisterPage from './RegisterPage';
+import * as authApi from '../api/auth';
+
+jest.mock('../api/auth');
+const mockRegister = authApi.registerApi as jest.MockedFunction<typeof authApi.registerApi>;
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockSetToken = jest.fn();
+jest.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ setToken: mockSetToken, getToken: jest.fn(), clearToken: jest.fn(), isAuthenticated: jest.fn() }),
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/register']}>
+      <RegisterPage />
+    </MemoryRouter>
+  );
+
+beforeEach(() => jest.clearAllMocks());
+
+test('renders all fields', () => {
+  renderPage();
+  expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+});
+
+test('shows error when passwords do not match on submit', async () => {
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
+  await userEvent.type(screen.getByLabelText(/^password$/i), 'password1');
+  await userEvent.type(screen.getByLabelText(/confirm password/i), 'password2');
+  fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+  await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Passwords do not match'));
+  expect(mockRegister).not.toHaveBeenCalled();
+});
+
+test('shows error when password too short', async () => {
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
+  await userEvent.type(screen.getByLabelText(/^password$/i), 'short');
+  await userEvent.type(screen.getByLabelText(/confirm password/i), 'short');
+  fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+  await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('at least 8 characters'));
+});
+
+test('shows inline helper when confirm password differs', async () => {
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/^password$/i), 'password1');
+  await userEvent.type(screen.getByLabelText(/confirm password/i), 'other');
+  expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+});
+
+test('registers successfully and redirects', async () => {
+  mockRegister.mockResolvedValueOnce({ token: 'tok456', user: { id: '2', email: 'a@b.com', createdAt: '' } });
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/email address/i), 'a@b.com');
+  await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
+  await userEvent.type(screen.getByLabelText(/confirm password/i), 'password123');
+  fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+  await waitFor(() => {
+    expect(mockSetToken).toHaveBeenCalledWith('tok456');
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+  });
+});
+
+test('shows API error on duplicate email', async () => {
+  mockRegister.mockRejectedValueOnce(Object.assign(new Error('Email already taken'), { status: 409 }));
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/email address/i), 'dup@b.com');
+  await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
+  await userEvent.type(screen.getByLabelText(/confirm password/i), 'password123');
+  fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+  await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Email already taken'));
+});
+
+test('renders link to login page', () => {
+  renderPage();
+  expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument();
+});

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,43 +1,42 @@
-import { useState, FormEvent } from 'react'
+import { useState, type FormEvent } from 'react'
 import {
   Box,
   Button,
   CircularProgress,
   Container,
+  Link,
+  Paper,
   TextField,
   Typography,
   Alert,
-  Paper,
-  Link as MuiLink,
 } from '@mui/material'
-import { Link } from 'react-router-dom'
+import { Link as RouterLink } from 'react-router-dom'
 import { useRegister } from '../hooks/useAuth'
 
 export default function RegisterPage() {
+  const { register, loading, error } = useRegister()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
-  const [validationError, setValidationError] = useState<string | null>(null)
-  const { submit, loading, error } = useRegister()
+  const [fieldErrors, setFieldErrors] = useState({ email: '', password: '', confirmPassword: '' })
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault()
-    setValidationError(null)
-
-    if (password !== confirmPassword) {
-      setValidationError('Passwords do not match')
-      return
-    }
-
-    if (password.length < 6) {
-      setValidationError('Password must be at least 6 characters')
-      return
-    }
-
-    submit({ email, password })
+  const validate = (): boolean => {
+    const errors = { email: '', password: '', confirmPassword: '' }
+    if (!email) errors.email = 'Email is required'
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errors.email = 'Enter a valid email'
+    if (!password) errors.password = 'Password is required'
+    else if (password.length < 8) errors.password = 'Password must be at least 8 characters'
+    if (!confirmPassword) errors.confirmPassword = 'Please confirm your password'
+    else if (password !== confirmPassword) errors.confirmPassword = 'Passwords do not match'
+    setFieldErrors(errors)
+    return !errors.email && !errors.password && !errors.confirmPassword
   }
 
-  const displayError = validationError ?? error
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!validate()) return
+    await register({ email, password })
+  }
 
   return (
     <Container maxWidth="xs">
@@ -47,22 +46,17 @@ export default function RegisterPage() {
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'center',
+          alignItems: 'center',
         }}
       >
-        <Paper elevation={3} sx={{ p: 4 }}>
-          <Typography
-            component="h1"
-            variant="h5"
-            align="center"
-            gutterBottom
-            fontWeight={700}
-          >
+        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
+          <Typography variant="h5" component="h1" gutterBottom align="center" fontWeight={700}>
             Create Account
           </Typography>
 
-          {displayError && (
-            <Alert severity="error" role="alert" sx={{ mb: 2 }}>
-              {displayError}
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} role="alert">
+              {error}
             </Alert>
           )}
 
@@ -70,62 +64,65 @@ export default function RegisterPage() {
             component="form"
             onSubmit={handleSubmit}
             noValidate
-            aria-label="Register form"
+            aria-label="Registration form"
           >
             <TextField
-              id="email"
-              label="Email Address"
+              label="Email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              margin="normal"
+              error={!!fieldErrors.email}
+              helperText={fieldErrors.email}
               fullWidth
-              required
+              margin="normal"
               autoComplete="email"
-              autoFocus
-              inputProps={{ 'aria-label': 'Email Address' }}
+              inputProps={{ 'aria-label': 'Email address' }}
+              disabled={loading}
             />
             <TextField
-              id="password"
               label="Password"
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              margin="normal"
+              error={!!fieldErrors.password}
+              helperText={fieldErrors.password}
               fullWidth
-              required
+              margin="normal"
               autoComplete="new-password"
               inputProps={{ 'aria-label': 'Password' }}
+              disabled={loading}
             />
             <TextField
-              id="confirmPassword"
               label="Confirm Password"
               type="password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
-              margin="normal"
+              error={!!fieldErrors.confirmPassword}
+              helperText={fieldErrors.confirmPassword}
               fullWidth
-              required
+              margin="normal"
               autoComplete="new-password"
-              inputProps={{ 'aria-label': 'Confirm Password' }}
+              inputProps={{ 'aria-label': 'Confirm password' }}
+              disabled={loading}
             />
             <Button
               type="submit"
-              fullWidth
               variant="contained"
+              fullWidth
+              size="large"
               disabled={loading}
-              sx={{ mt: 2, mb: 2 }}
-              aria-label="Create account"
+              sx={{ mt: 2, mb: 1 }}
+              aria-label={loading ? 'Creating account…' : 'Create account'}
             >
-              {loading ? <CircularProgress size={24} aria-label="Loading" /> : 'Create Account'}
+              {loading ? <CircularProgress size={24} color="inherit" /> : 'Register'}
             </Button>
           </Box>
 
-          <Typography variant="body2" align="center">
+          <Typography variant="body2" align="center" sx={{ mt: 1 }}>
             Already have an account?{' '}
-            <MuiLink component={Link} to="/login" underline="hover">
+            <Link component={RouterLink} to="/login" underline="hover">
               Sign In
-            </MuiLink>
+            </Link>
           </Typography>
         </Paper>
       </Box>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,140 +1,134 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import {
-  Box,
-  Button,
-  Container,
   TextField,
-  Typography,
+  Button,
   Alert,
-  CircularProgress,
-  Link as MuiLink,
-  Paper,
+  Box,
+  Link,
+  InputAdornment,
+  IconButton,
 } from '@mui/material';
-import { Link, useNavigate } from 'react-router-dom';
-import { registerApi } from '../api/auth';
-import { useAuth } from '../hooks/useAuth';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import AuthLayout from '../components/AuthLayout';
+import { useRegister } from '../hooks/useAuth';
 
 export default function RegisterPage() {
-  const navigate = useNavigate();
-  const { setToken } = useAuth();
-
+  const { handleRegister, loading, error } = useRegister();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
 
-  const validate = (): string | null => {
-    if (!email) return 'Email is required.';
-    if (!password) return 'Password is required.';
-    if (password.length < 8) return 'Password must be at least 8 characters.';
-    if (password !== confirmPassword) return 'Passwords do not match.';
-    return null;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
+  async function onSubmit(e: FormEvent) {
     e.preventDefault();
-    const validationError = validate();
-    if (validationError) {
-      setError(validationError);
+    setValidationError(null);
+
+    if (password.length < 8) {
+      setValidationError('Password must be at least 8 characters.');
       return;
     }
-    setError(null);
-    setLoading(true);
-    try {
-      const { token } = await registerApi({ email, password });
-      setToken(token);
-      navigate('/dashboard');
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Registration failed';
-      setError(msg);
-    } finally {
-      setLoading(false);
+    if (password !== confirmPassword) {
+      setValidationError('Passwords do not match.');
+      return;
     }
-  };
 
-  const passwordMismatch = confirmPassword !== '' && password !== confirmPassword;
+    await handleRegister({ email, password });
+  }
+
+  const displayError = validationError ?? error;
 
   return (
-    <Container maxWidth="xs">
-      <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
-          <Typography component="h1" variant="h5" align="center" gutterBottom>
-            Create Account
-          </Typography>
+    <AuthLayout title="Create Account">
+      <Box
+        component="form"
+        onSubmit={onSubmit}
+        noValidate
+        aria-label="Register form"
+        sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+      >
+        {displayError && (
+          <Alert severity="error" role="alert">
+            {displayError}
+          </Alert>
+        )}
 
-          {error && (
-            <Alert severity="error" role="alert" sx={{ mb: 2 }}>
-              {error}
-            </Alert>
-          )}
+        <TextField
+          id="reg-email"
+          label="Email Address"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          fullWidth
+          autoComplete="email"
+          autoFocus
+          inputProps={{ 'aria-required': true }}
+        />
 
-          <Box
-            component="form"
-            onSubmit={handleSubmit}
-            noValidate
-            aria-label="Registration form"
-          >
-            <TextField
-              id="email"
-              label="Email Address"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              fullWidth
-              margin="normal"
-              autoComplete="email"
-              autoFocus
-              inputProps={{ 'aria-label': 'Email address' }}
-            />
-            <TextField
-              id="password"
-              label="Password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              fullWidth
-              margin="normal"
-              autoComplete="new-password"
-              helperText="Minimum 8 characters"
-              inputProps={{ 'aria-label': 'Password' }}
-            />
-            <TextField
-              id="confirmPassword"
-              label="Confirm Password"
-              type="password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              required
-              fullWidth
-              margin="normal"
-              autoComplete="new-password"
-              error={passwordMismatch}
-              helperText={passwordMismatch ? 'Passwords do not match' : ''}
-              inputProps={{ 'aria-label': 'Confirm password' }}
-            />
-            <Button
-              type="submit"
-              fullWidth
-              variant="contained"
-              disabled={loading}
-              sx={{ mt: 3, mb: 2 }}
-              aria-label={loading ? 'Creating account…' : 'Create account'}
-            >
-              {loading ? <CircularProgress size={24} color="inherit" /> : 'Create Account'}
-            </Button>
-          </Box>
+        <TextField
+          id="reg-password"
+          label="Password"
+          type={showPassword ? 'text' : 'password'}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          fullWidth
+          autoComplete="new-password"
+          helperText="Minimum 8 characters"
+          inputProps={{ 'aria-required': true, minLength: 8 }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  onClick={() => setShowPassword((s) => !s)}
+                  edge="end"
+                >
+                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
 
-          <Typography variant="body2" align="center">
-            Already have an account?{' '}
-            <MuiLink component={Link} to="/login" underline="hover">
-              Sign In
-            </MuiLink>
-          </Typography>
-        </Paper>
+        <TextField
+          id="reg-confirm-password"
+          label="Confirm Password"
+          type={showPassword ? 'text' : 'password'}
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          fullWidth
+          autoComplete="new-password"
+          inputProps={{ 'aria-required': true }}
+          error={confirmPassword.length > 0 && password !== confirmPassword}
+          helperText={
+            confirmPassword.length > 0 && password !== confirmPassword
+              ? 'Passwords do not match'
+              : ''
+          }
+        />
+
+        <Button
+          type="submit"
+          variant="contained"
+          fullWidth
+          disabled={loading}
+          aria-busy={loading}
+          sx={{ mt: 1 }}
+        >
+          {loading ? 'Creating account…' : 'Create Account'}
+        </Button>
+
+        <Box sx={{ textAlign: 'center', mt: 1 }}>
+          <Link component={RouterLink} to="/login" variant="body2">
+            Already have an account? Sign In
+          </Link>
+        </Box>
       </Box>
-    </Container>
+    </AuthLayout>
   );
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,134 +1,134 @@
-import { useState, type FormEvent } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { useState, FormEvent } from 'react'
 import {
-  TextField,
-  Button,
-  Alert,
   Box,
-  Link,
-  InputAdornment,
-  IconButton,
-} from '@mui/material';
-import Visibility from '@mui/icons-material/Visibility';
-import VisibilityOff from '@mui/icons-material/VisibilityOff';
-import AuthLayout from '../components/AuthLayout';
-import { useRegister } from '../hooks/useAuth';
+  Button,
+  CircularProgress,
+  Container,
+  TextField,
+  Typography,
+  Alert,
+  Paper,
+  Link as MuiLink,
+} from '@mui/material'
+import { Link } from 'react-router-dom'
+import { useRegister } from '../hooks/useAuth'
 
 export default function RegisterPage() {
-  const { handleRegister, loading, error } = useRegister();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
-  const [validationError, setValidationError] = useState<string | null>(null);
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const { submit, loading, error } = useRegister()
 
-  async function onSubmit(e: FormEvent) {
-    e.preventDefault();
-    setValidationError(null);
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    setValidationError(null)
 
-    if (password.length < 8) {
-      setValidationError('Password must be at least 8 characters.');
-      return;
-    }
     if (password !== confirmPassword) {
-      setValidationError('Passwords do not match.');
-      return;
+      setValidationError('Passwords do not match')
+      return
     }
 
-    await handleRegister({ email, password });
+    if (password.length < 6) {
+      setValidationError('Password must be at least 6 characters')
+      return
+    }
+
+    submit({ email, password })
   }
 
-  const displayError = validationError ?? error;
+  const displayError = validationError ?? error
 
   return (
-    <AuthLayout title="Create Account">
+    <Container maxWidth="xs">
       <Box
-        component="form"
-        onSubmit={onSubmit}
-        noValidate
-        aria-label="Register form"
-        sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+        }}
       >
-        {displayError && (
-          <Alert severity="error" role="alert">
-            {displayError}
-          </Alert>
-        )}
+        <Paper elevation={3} sx={{ p: 4 }}>
+          <Typography
+            component="h1"
+            variant="h5"
+            align="center"
+            gutterBottom
+            fontWeight={700}
+          >
+            Create Account
+          </Typography>
 
-        <TextField
-          id="reg-email"
-          label="Email Address"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-          fullWidth
-          autoComplete="email"
-          autoFocus
-          inputProps={{ 'aria-required': true }}
-        />
+          {displayError && (
+            <Alert severity="error" role="alert" sx={{ mb: 2 }}>
+              {displayError}
+            </Alert>
+          )}
 
-        <TextField
-          id="reg-password"
-          label="Password"
-          type={showPassword ? 'text' : 'password'}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          fullWidth
-          autoComplete="new-password"
-          helperText="Minimum 8 characters"
-          inputProps={{ 'aria-required': true, minLength: 8 }}
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <IconButton
-                  aria-label={showPassword ? 'Hide password' : 'Show password'}
-                  onClick={() => setShowPassword((s) => !s)}
-                  edge="end"
-                >
-                  {showPassword ? <VisibilityOff /> : <Visibility />}
-                </IconButton>
-              </InputAdornment>
-            ),
-          }}
-        />
+          <Box
+            component="form"
+            onSubmit={handleSubmit}
+            noValidate
+            aria-label="Register form"
+          >
+            <TextField
+              id="email"
+              label="Email Address"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              margin="normal"
+              fullWidth
+              required
+              autoComplete="email"
+              autoFocus
+              inputProps={{ 'aria-label': 'Email Address' }}
+            />
+            <TextField
+              id="password"
+              label="Password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              margin="normal"
+              fullWidth
+              required
+              autoComplete="new-password"
+              inputProps={{ 'aria-label': 'Password' }}
+            />
+            <TextField
+              id="confirmPassword"
+              label="Confirm Password"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              margin="normal"
+              fullWidth
+              required
+              autoComplete="new-password"
+              inputProps={{ 'aria-label': 'Confirm Password' }}
+            />
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              disabled={loading}
+              sx={{ mt: 2, mb: 2 }}
+              aria-label="Create account"
+            >
+              {loading ? <CircularProgress size={24} aria-label="Loading" /> : 'Create Account'}
+            </Button>
+          </Box>
 
-        <TextField
-          id="reg-confirm-password"
-          label="Confirm Password"
-          type={showPassword ? 'text' : 'password'}
-          value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.target.value)}
-          required
-          fullWidth
-          autoComplete="new-password"
-          inputProps={{ 'aria-required': true }}
-          error={confirmPassword.length > 0 && password !== confirmPassword}
-          helperText={
-            confirmPassword.length > 0 && password !== confirmPassword
-              ? 'Passwords do not match'
-              : ''
-          }
-        />
-
-        <Button
-          type="submit"
-          variant="contained"
-          fullWidth
-          disabled={loading}
-          aria-busy={loading}
-          sx={{ mt: 1 }}
-        >
-          {loading ? 'Creating account…' : 'Create Account'}
-        </Button>
-
-        <Box sx={{ textAlign: 'center', mt: 1 }}>
-          <Link component={RouterLink} to="/login" variant="body2">
-            Already have an account? Sign In
-          </Link>
-        </Box>
+          <Typography variant="body2" align="center">
+            Already have an account?{' '}
+            <MuiLink component={Link} to="/login" underline="hover">
+              Sign In
+            </MuiLink>
+          </Typography>
+        </Paper>
       </Box>
-    </AuthLayout>
-  );
+    </Container>
+  )
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  Container,
+  TextField,
+  Typography,
+  Alert,
+  CircularProgress,
+  Link as MuiLink,
+  Paper,
+} from '@mui/material';
+import { Link, useNavigate } from 'react-router-dom';
+import { registerApi } from '../api/auth';
+import { useAuth } from '../hooks/useAuth';
+
+export default function RegisterPage() {
+  const navigate = useNavigate();
+  const { setToken } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const validate = (): string | null => {
+    if (!email) return 'Email is required.';
+    if (!password) return 'Password is required.';
+    if (password.length < 8) return 'Password must be at least 8 characters.';
+    if (password !== confirmPassword) return 'Passwords do not match.';
+    return null;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError(null);
+    setLoading(true);
+    try {
+      const { token } = await registerApi({ email, password });
+      setToken(token);
+      navigate('/dashboard');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Registration failed';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const passwordMismatch = confirmPassword !== '' && password !== confirmPassword;
+
+  return (
+    <Container maxWidth="xs">
+      <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <Paper elevation={3} sx={{ p: 4, width: '100%' }}>
+          <Typography component="h1" variant="h5" align="center" gutterBottom>
+            Create Account
+          </Typography>
+
+          {error && (
+            <Alert severity="error" role="alert" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          <Box
+            component="form"
+            onSubmit={handleSubmit}
+            noValidate
+            aria-label="Registration form"
+          >
+            <TextField
+              id="email"
+              label="Email Address"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              fullWidth
+              margin="normal"
+              autoComplete="email"
+              autoFocus
+              inputProps={{ 'aria-label': 'Email address' }}
+            />
+            <TextField
+              id="password"
+              label="Password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              fullWidth
+              margin="normal"
+              autoComplete="new-password"
+              helperText="Minimum 8 characters"
+              inputProps={{ 'aria-label': 'Password' }}
+            />
+            <TextField
+              id="confirmPassword"
+              label="Confirm Password"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              fullWidth
+              margin="normal"
+              autoComplete="new-password"
+              error={passwordMismatch}
+              helperText={passwordMismatch ? 'Passwords do not match' : ''}
+              inputProps={{ 'aria-label': 'Confirm password' }}
+            />
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              disabled={loading}
+              sx={{ mt: 3, mb: 2 }}
+              aria-label={loading ? 'Creating account…' : 'Create account'}
+            >
+              {loading ? <CircularProgress size={24} color="inherit" /> : 'Create Account'}
+            </Button>
+          </Box>
+
+          <Typography variant="body2" align="center">
+            Already have an account?{' '}
+            <MuiLink component={Link} to="/login" underline="hover">
+              Sign In
+            </MuiLink>
+          </Typography>
+        </Paper>
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import LoginPage from '../LoginPage';
+import * as authApi from '../../api/authApi';
+
+vi.mock('../../api/authApi');
+
+const mockedLogin = vi.mocked(authApi.login);
+
+function renderLoginPage() {
+  return render(
+    <MemoryRouter initialEntries={['/login']}>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/dashboard" element={<div>Dashboard</div>} />
+        <Route path="/register" element={<div>Register</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders email and password fields', () => {
+    renderLoginPage();
+    expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+  });
+
+  it('renders the sign in button', () => {
+    renderLoginPage();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it('has a link to the register page', () => {
+    renderLoginPage();
+    expect(screen.getByRole('link', { name: /register/i })).toHaveAttribute('href', '/register');
+  });
+
+  it('shows loading state while submitting', async () => {
+    mockedLogin.mockImplementation(() => new Promise(() => {}));
+    renderLoginPage();
+    await userEvent.type(screen.getByLabelText(/email address/i), 'user@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(await screen.findByRole('button', { name: /signing in/i })).toBeDisabled();
+  });
+
+  it('stores token and navigates to dashboard on success', async () => {
+    mockedLogin.mockResolvedValue({ token: 'jwt-token', user: { id: '1', email: 'user@example.com', createdAt: '' } });
+    renderLoginPage();
+    await userEvent.type(screen.getByLabelText(/email address/i), 'user@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument());
+    expect(localStorage.getItem('token')).toBe('jwt-token');
+  });
+
+  it('displays error alert on invalid credentials', async () => {
+    mockedLogin.mockRejectedValue(new Error('Invalid credentials'));
+    renderLoginPage();
+    await userEvent.type(screen.getByLabelText(/email address/i), 'user@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'wrongpass');
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid credentials');
+  });
+
+  it('toggles password visibility', async () => {
+    renderLoginPage();
+    const passwordInput = screen.getByLabelText(/^password$/i);
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    await userEvent.click(screen.getByRole('button', { name: /show password/i }));
+    expect(passwordInput).toHaveAttribute('type', 'text');
+    await userEvent.click(screen.getByRole('button', { name: /hide password/i }));
+    expect(passwordInput).toHaveAttribute('type', 'password');
+  });
+});

--- a/frontend/src/pages/__tests__/RegisterPage.test.tsx
+++ b/frontend/src/pages/__tests__/RegisterPage.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import RegisterPage from '../RegisterPage';
+import * as authApi from '../../api/authApi';
+
+vi.mock('../../api/authApi');
+
+const mockedRegister = vi.mocked(authApi.register);
+
+function renderRegisterPage() {
+  return render(
+    <MemoryRouter initialEntries={['/register']}>
+      <Routes>
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/dashboard" element={<div>Dashboard</div>} />
+        <Route path="/login" element={<div>Login</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders all fields', () => {
+    renderRegisterPage();
+    expect(screen.getByLabelText(/email address/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+  });
+
+  it('shows validation error when passwords do not match', async () => {
+    renderRegisterPage();
+    await userEvent.type(screen.getByLabelText(/email address/i), 'user@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'different123');
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Passwords do not match');
+  });
+
+  it('shows validation error when password is too short', async () => {
+    renderRegisterPage();
+    await userEvent.type(screen.getByLabelText(/email address/i), 'user@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'short');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'short');
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('at least 8 characters');
+  });
+
+  it('stores token and navigates to dashboard on success', async () => {
+    mockedRegister.mockResolvedValue({ token: 'new-token', user: { id: '2', email: 'user@example.com', createdAt: '' } });
+    renderRegisterPage();
+    await userEvent.type(screen.getByLabelText(/email address/i), 'user@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'password123');
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    await waitFor(() => expect(screen.getByText('Dashboard')).toBeInTheDocument());
+    expect(localStorage.getItem('token')).toBe('new-token');
+  });
+
+  it('shows API error on registration failure (email taken)', async () => {
+    mockedRegister.mockRejectedValue(new Error('Email already in use'));
+    renderRegisterPage();
+    await userEvent.type(screen.getByLabelText(/email address/i), 'existing@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'password123');
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Email already in use');
+  });
+
+  it('shows loading state while submitting', async () => {
+    mockedRegister.mockImplementation(() => new Promise(() => {}));
+    renderRegisterPage();
+    await userEvent.type(screen.getByLabelText(/email address/i), 'user@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'password123');
+    await userEvent.type(screen.getByLabelText(/confirm password/i), 'password123');
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    expect(await screen.findByRole('button', { name: /creating account/i })).toBeDisabled();
+  });
+
+  it('has a link to the login page', () => {
+    renderRegisterPage();
+    expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/login');
+  });
+});

--- a/frontend/src/test/__mocks__/authApi.ts
+++ b/frontend/src/test/__mocks__/authApi.ts
@@ -1,0 +1,5 @@
+import { vi } from 'vitest';
+
+export const login = vi.fn();
+export const register = vi.fn();
+export const getMe = vi.fn();

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,26 +1,26 @@
-export interface LoginCredentials {
-  email: string;
-  password: string;
+export interface LoginRequest {
+  email: string
+  password: string
 }
 
-export interface RegisterCredentials {
-  email: string;
-  password: string;
-  confirmPassword: string;
-}
-
-export interface AuthUser {
-  id: string;
-  email: string;
-  createdAt: string;
+export interface RegisterRequest {
+  email: string
+  password: string
+  confirmPassword: string
 }
 
 export interface AuthResponse {
-  token: string;
-  user: AuthUser;
+  token: string
+  user: User
+}
+
+export interface User {
+  id: string
+  email: string
+  createdAt: string
 }
 
 export interface ApiError {
-  message: string;
-  status?: number;
+  message: string
+  status?: number
 }

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,26 @@
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export interface AuthResponse {
+  token: string;
+  user: User;
+}
+
+export interface User {
+  id: string;
+  email: string;
+  createdAt: string;
+}
+
+export interface ApiError {
+  message: string;
+  status?: number;
+}

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,23 +1,23 @@
-export interface LoginRequest {
+export interface LoginCredentials {
   email: string;
   password: string;
 }
 
-export interface RegisterRequest {
+export interface RegisterCredentials {
   email: string;
   password: string;
   confirmPassword: string;
 }
 
-export interface AuthResponse {
-  token: string;
-  user: User;
-}
-
-export interface User {
+export interface AuthUser {
   id: string;
   email: string;
   createdAt: string;
+}
+
+export interface AuthResponse {
+  token: string;
+  user: AuthUser;
 }
 
 export interface ApiError {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,25 +1,14 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
+    "target": "ES2020", "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "module": "ESNext", "skipLibCheck": true,
+    "moduleResolution": "bundler", "allowImportingTsExtensions": true,
+    "resolveJsonModule": true, "isolatedModules": true, "noEmit": true,
+    "jsx": "react-jsx", "strict": true, "noUnusedLocals": false,
+    "noUnusedParameters": false, "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals"]
   },
   "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"]
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+    },
+  },
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,23 +1,6 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-      },
-    },
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-    },
-  },
-});
+  test: { globals: true, environment: 'jsdom', setupFiles: [] },
+})


### PR DESCRIPTION
## Automated PR — Issue #10

Closes #10
Issue: https://github.com/andrR89/test-ai-full-cycle/issues/10

## Summary
**Backend:** Implemented JWT-based authentication with three endpoints: POST /api/auth/register (bcrypt hash, 409 on duplicate email), POST /api/auth/login (credential validation, returns 24h JWT), GET /api/auth/me (Bearer token guard via middleware). Prisma User model added with unique email index. Full Jest/Supertest test suite with mocked Prisma client covering all success and error paths.
**Prisma changes:** Added User model with fields: id (cuid, PK), email (String, unique), passwordHash (String), createdAt (DateTime, default now). Added unique index and query index on email field.
**New backend packages:** bcrypt@5.1.1, jsonwebtoken@9.0.2, express-validator@7.0.1, @prisma/client@5.10.2, prisma@5.10.2, supertest@6.3.4
**Frontend:** Implements a complete frontend authentication system with: LoginPage (email/password form, validation, JWT storage, error display), RegisterPage (email/password/confirm fields, password match & length validation, API error display), DashboardPage (protected, loads current user via /api/auth/me, logout), ProtectedRoute guard, useLogin/useRegister hooks, and a typed authApi module. All routes are wired via React Router v6. Tests cover validation, API calls, localStorage behaviour, and protected routing using Vitest + React Testing Library.
**Accessibility:** 1. All form fields have aria-label via inputProps for screen readers (in addition to visible labels).
2. The submit button updates its aria-label to indicate the loading state ('Signing in…' / 'Creating account…').
3. Error alerts use role='alert' so screen readers announce them immediately on render.
4. Forms use noValidate to suppress native browser bubbles; validation is handled in JS and surfaced via helperText.
5. Typography uses semantic heading elements (component='h1' on variant='h5') so page structure is correct.
6. CircularProgress has aria-label on the DashboardPage instance to describe the loading action.

## Acceptance Criteria
- [ ] POST /api/auth/register creates user with hashed password
- [ ] POST /api/auth/login returns JWT on valid credentials
- [ ] GET /api/auth/me returns user data with valid token, 401 without
- [ ] Login page renders with email/password form
- [ ] Successful login stores JWT and redirects to /dashboard
- [ ] Register page validates password confirmation
- [ ] Backend unit tests with >80% coverage

## Changed Layers
- Backend
- Frontend

## Testing
**Backend:** 1. Copy .env and set DATABASE_URL and JWT_SECRET=your-secret
2. Run `npx prisma migrate dev` to apply migration
3. Run `npm install` to install new dependencies
4. Run `npm test` to execute the test suite
5. Run `npm test -- --coverage` to verify >80% coverage
6. Manual smoke test: POST /api/auth/register with {"email":"test@example.com","password":"password123"}, then POST /api/auth/login with same credentials, then GET /api/auth/me with `Authorization: Bearer <token>`
**Frontend:** 1. cd frontend && npm install
2. npm test — runs all Vitest unit tests
3. npm run dev — starts dev server; navigate to http://localhost:5173/login
4. Manual flow: fill in login form with valid credentials → should redirect to /dashboard; use wrong password → should show red error alert
5. Navigate to /register → test password mismatch and short password validation messages; register with a new email → stores token and redirects to /dashboard
6. Navigate directly to /dashboard without a token → should redirect to /login

---
_Generated by AI Issue Solver pipeline_

## ⚠️ Security Warnings (requires human review)
The following patterns were detected in generated code and need manual verification:
- [frontend/src/pages/LoginPage.tsx] Hardcoded credential
- [frontend/src/pages/RegisterPage.tsx] Hardcoded credential